### PR TITLE
Replace lodash with lodash-es

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,10 +12,10 @@ module.exports = {
     '^.+\\.ts$': 'ts-jest',
     "^.+\\.(js|jsx)$": 'babel-jest'
   },
-  // Allow transpiling SMUI modules.
+  // Allow transpiling SMUI and lodash-es modules.
   // https://jestjs.io/docs/en/configuration#transformignorepatterns-arraystring
   transformIgnorePatterns: [
-    "node_modules/(?!(@smui)/)"
+    "node_modules/(?!(@smui|lodash-es)/)"
   ],
   moduleFileExtensions: [
     'js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -3220,6 +3220,15 @@
       "integrity": "sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==",
       "dev": true
     },
+    "@types/lodash-es": {
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.3.tgz",
+      "integrity": "sha512-iHI0i7ZAL1qepz1Y7f3EKg/zUMDwDfTzitx+AlHhJJvXwenP682ZyGbgPSc5Ej3eEAKVbNWKFuwOadCj5vBbYQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -9258,7 +9267,14 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
+    },
+    "lodash-es": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
+      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==",
+      "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/faker": "^5.1.5",
     "@types/firefox-webext-browser": "^82.0.0",
     "@types/jest": "^26.0.16",
-    "@types/lodash": "^4.14.165",
+    "@types/lodash-es": "^4.17.3",
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",
     "babel-jest": "^26.6.3",
@@ -45,6 +45,7 @@
     "eslint-plugin-svelte3": "^2.7.3",
     "faker": "^5.1.0",
     "jest": "^26.6.3",
+    "lodash-es": "^4.17.15",
     "mockzilla": "^0.9.0",
     "mockzilla-webextension": "^0.9.0",
     "normalize.css": "^8.0.1",
@@ -64,9 +65,7 @@
     "typescript": "^4.1.2",
     "webextension-polyfill-ts": "^0.22.0"
   },
-  "dependencies": {
-    "lodash": "^4.17.20"
-  },
+  "dependencies": {},
   "webExt": {
     "sourceDir": "./dist"
   }

--- a/src/treetop/Bookmark.svelte
+++ b/src/treetop/Bookmark.svelte
@@ -3,9 +3,7 @@
   import type { Writable } from 'svelte/store';
 
   import { getContext } from 'svelte';
-  // FIXME: truncate is unavailable in jest when imported directly
-  // import lodashTruncate from 'lodash/truncate';
-  import { truncate as lodashTruncate } from 'lodash';
+  import lodashTruncate from 'lodash-es/truncate';
 
   import { clock } from './clock';
   import { truncateMiddle } from './utils';

--- a/src/treetop/PropertiesDialog.svelte
+++ b/src/treetop/PropertiesDialog.svelte
@@ -8,7 +8,7 @@
   import TextField from '@smui/textfield';
 
   import { createEventDispatcher } from 'svelte';
-  import truncate from 'lodash/truncate';
+  import truncate from 'lodash-es/truncate';
 
   const dispatch = createEventDispatcher();
 

--- a/test/treetop/Bookmark.svelte.test.ts
+++ b/test/treetop/Bookmark.svelte.test.ts
@@ -1,7 +1,7 @@
 import { Writable, writable } from 'svelte/store';
 import { render, screen } from '@testing-library/svelte';
 import faker from 'faker';
-import { escapeRegExp } from 'lodash';
+import escapeRegExp from 'lodash-es/escapeRegExp';
 
 import Bookmark from '@Treetop/treetop/Bookmark.svelte';
 import type * as Treetop from '@Treetop/treetop/types';


### PR DESCRIPTION
Replace the lodash package with lodash-es and update the Jest configuration to transpile lodash-es modules. This resolves a problem where the lodash truncate function wasn't available in tests when imported like:

```js
import { truncate } from 'lodash/truncate';
````

Previously, the entire lodash package was imported to work around the problem.