### PR TITLE
Enable searching for bookmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Treetop is a Firefox extension that provides a high-level live view of your book
 
 - Recently visited bookmarks have a larger font.
 
-### Edit your bookmarks
+### Find and edit your bookmarks
+
+- Search for bookmarks by name or URL.
 
 - Right-click to edit or delete bookmarks and folders.
 
@@ -28,7 +30,7 @@ Treetop is a Firefox extension that provides a high-level live view of your book
 
 - Click the Preferences button to customize Treetop's display.
 
-- Click a folder to set Treetop's root.
+- Click on a folder to make it the root folder.
 
 ## Development
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -11,6 +11,14 @@
     "message": "Preferences",
     "description": "Label on button to open preferences."
   },
+  "search": {
+    "message": "Search",
+    "description": "Label for search input."
+  },
+  "noResults": {
+    "message": "No results",
+    "description": "Display text when there are no matches for a search."
+  },
   "menuItemOpenAllInTabs": {
     "message": "&Open All in Tabs",
     "description": "Title of context menu item that opens all of a folder's bookmarks in new tabs."

--- a/src/treetop/FilterInput.svelte
+++ b/src/treetop/FilterInput.svelte
@@ -1,0 +1,67 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+
+  import TextField from '@smui/textfield';
+
+  import debounce from 'lodash-es/debounce';
+  import { browser } from 'webextension-polyfill-ts';
+
+  // Filter string
+  let filter = '';
+
+  // Debounce duration for typing in filter input (ms)
+  const FILTER_DEBOUNCE_MS = 275;
+
+  const dispatch = createEventDispatcher<{ input: { filter: string } }>();
+
+  /**
+   * Dispatch an input event with the current filter string.
+   */
+  function dispatchInputEvent() {
+    dispatch('input', { filter });
+  }
+
+  /**
+   * Filter input event handler.
+   */
+  function handleFilterInput(event: Event) {
+    event.preventDefault();
+
+    dispatchInputEvent();
+  }
+
+  /**
+   * Filter submit event handler.
+   */
+  function handleFilterSubmit(event: Event) {
+    event.preventDefault();
+
+    // Cancel the debounced filter input handler because we update the filter
+    // immediately
+    debounceFilterInput.cancel();
+
+    dispatchInputEvent();
+  }
+
+  /**
+   * Debounced filter input handler.
+   */
+  const debounceFilterInput = debounce((event: Event) => {
+    handleFilterInput(event);
+  }, FILTER_DEBOUNCE_MS);
+</script>
+
+<style>
+  .searchBox {
+    padding: 0 1em;
+  }
+</style>
+
+<div class="searchBox">
+  <form on:submit={handleFilterSubmit}>
+    <TextField
+      bind:value={filter}
+      on:input={debounceFilterInput}
+      label={browser.i18n.getMessage('search')} />
+  </form>
+</div>

--- a/src/treetop/FilterManager.ts
+++ b/src/treetop/FilterManager.ts
@@ -1,0 +1,193 @@
+import { get } from 'svelte/store';
+
+import { BOOKMARK_TREE_NODE_TYPE_BOOKMARK } from './constants';
+import * as Treetop from './types';
+
+/**
+ * Class to identify bookmarks that match a filter string.
+ * Matching applies to the title and URL and is case-insensitive.
+ *
+ * When one or more bookmarks match a filter, the FilterSet contains the IDs of:
+ * - the matching bookmarks
+ * - all the folders above each bookmark on the path to the root folder
+ */
+export class FilterManager {
+  private filter: string | null = null;
+  private inBatchRemove = false;
+
+  constructor(
+    private readonly filterSet: Treetop.FilterSet,
+    private readonly nodeStoreMap: Treetop.NodeStoreMap
+  ) {}
+
+  /**
+   * Set a filter string and update the FilterSet.
+   */
+  setFilter(filter: string): void {
+    this.filter = filter.toLowerCase();
+
+    const filterSet = get(this.filterSet);
+
+    // Pass 1:
+    // Add bookmarks that match the filter string to the FilterSet.
+    // Additionally, add their immediate parent folders to the FilterSet.
+    for (const nodeStore of this.nodeStoreMap.values()) {
+      const startFilterSetSize = filterSet.size;
+
+      const folderNode: Treetop.FolderNode = get(nodeStore);
+      folderNode.children.forEach((child) => {
+        if (child.type === Treetop.NodeType.Bookmark) {
+          if (
+            this.matchesFilter(child.title) ||
+            this.matchesFilter(child.url)
+          ) {
+            filterSet.add(child.id);
+          }
+        }
+      });
+
+      if (filterSet.size > startFilterSetSize) {
+        filterSet.add(folderNode.id);
+      }
+    }
+
+    // Pass 2
+    // For each folder in the FilterSet, add the folders on the path to the root
+    // folder.
+    for (const nodeStore of this.nodeStoreMap.values()) {
+      const node: Treetop.FolderNode = get(nodeStore);
+      if (filterSet.has(node.id)) {
+        let curNode = node;
+        while (curNode.parentId) {
+          curNode = get(this.nodeStoreMap.get(curNode.parentId)!);
+          filterSet.add(curNode.id);
+        }
+      }
+    }
+
+    this.filterSet.set(filterSet);
+  }
+
+  /**
+   * Clear the filter string.
+   */
+  clearFilter(): void {
+    this.filter = null;
+
+    this.filterSet.update((filterSet) => {
+      filterSet.clear();
+      return filterSet;
+    });
+  }
+
+  /**
+   * Update the FilterSet for a newly created bookmark node.
+   */
+  handleBookmarkCreated(
+    _id: string,
+    bookmark: browser.bookmarks.BookmarkTreeNode
+  ): void {
+    if (this.filter === null) {
+      return;
+    }
+
+    if (bookmark.type !== BOOKMARK_TREE_NODE_TYPE_BOOKMARK) {
+      return;
+    }
+
+    if (
+      !this.matchesFilter(bookmark.title) &&
+      !this.matchesFilter(bookmark.url!)
+    ) {
+      return;
+    }
+
+    const filterSet = get(this.filterSet);
+
+    // Add the bookmark to the FilterSet
+    filterSet.add(bookmark.id);
+
+    // Add the folders on the path to the root folder to the FilterSet
+    let parentId = bookmark.parentId;
+    while (parentId) {
+      const node = get(this.nodeStoreMap.get(parentId)!);
+      filterSet.add(node.id);
+      parentId = node.parentId;
+    }
+
+    this.filterSet.set(filterSet);
+  }
+
+  /**
+   * Indicate the start of a batch removal of bookmarks.
+   * The updates may be delayed until the end of the batch.
+   */
+  beginBatchRemove(): void {
+    this.inBatchRemove = true;
+  }
+
+  /**
+   * Indicate the end of a batch removal of bookmarks.
+   */
+  endBatchRemove(): void {
+    if (this.inBatchRemove) {
+      this.inBatchRemove = false;
+      this.refreshFilter();
+    }
+  }
+
+  /**
+   * Update the FilterSet for a removed bookmark.
+   */
+  handleBookmarkRemoved(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _id: string
+  ): void {
+    if (!this.inBatchRemove) {
+      this.refreshFilter();
+    }
+  }
+
+  /**
+   * Update the FilterSet for a modified bookmark.
+   */
+  handleBookmarkChanged(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _id: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _changeInfo: browser.bookmarks._OnChangedChangeInfo
+  ): void {
+    this.refreshFilter();
+  }
+
+  /**
+   * Update the Filterset when a bookmark is moved to a different folder or to a
+   * new offset within its folder.
+   */
+  handleBookmarkMoved(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _id: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _moveInfo: browser.bookmarks._OnMovedMoveInfo
+  ): void {
+    this.refreshFilter();
+  }
+
+  /**
+   * Check whether a string matches the filter case-insensitively.
+   */
+  private matchesFilter(str: string) {
+    return str.toLowerCase().includes(this.filter!);
+  }
+
+  /**
+   * Clear and rebuild the FilterSet.
+   */
+  private refreshFilter() {
+    const filter = this.filter;
+    if (filter) {
+      this.clearFilter();
+      this.setFilter(filter);
+    }
+  }
+}

--- a/src/treetop/Folder.svelte
+++ b/src/treetop/Folder.svelte
@@ -13,6 +13,8 @@
   export let root: boolean = false;
 
   const nodeStoreMap: Treetop.NodeStoreMap = getContext('nodeStoreMap');
+  const filterActive = getContext<Writable<boolean>>('filterActive');
+  const filterSet = getContext<Treetop.FilterSet>('filterSet');
 
   let node: Writable<Treetop.FolderNode> = nodeStoreMap.get(nodeId)!;
 
@@ -121,7 +123,7 @@
   {/if}
 </svelte:head>
 
-{#if $node}
+{#if $node && (root || !$filterActive || $filterSet.has($node.id))}
   <div class="folder" class:root>
     <div class="heading">
       <div class="title">
@@ -134,9 +136,14 @@
       </div>
     </div>
     <div class="contents">
+      {#if root && $filterActive && !$filterSet.has(nodeId)}
+        <em>{browser.i18n.getMessage('noResults')}</em>
+      {/if}
       {#each $node.children as child (child.id)}
         {#if child.type === Treetop.NodeType.Bookmark}
-          <Bookmark nodeId={child.id} title={child.title} url={child.url} />
+          {#if !$filterActive || $filterSet.has(child.id)}
+            <Bookmark nodeId={child.id} title={child.title} url={child.url} />
+          {/if}
         {:else if child.type === Treetop.NodeType.Folder}
           <svelte:self nodeId={child.id} />
         {:else if child.type === Treetop.NodeType.Separator}

--- a/src/treetop/PageHeader.svelte
+++ b/src/treetop/PageHeader.svelte
@@ -37,7 +37,6 @@
   }
 
   .treetop {
-    flex: 1;
     font-family: 'News Cycle', sans-serif;
     font-size: 3rem;
     font-weight: 400;
@@ -45,6 +44,12 @@
     text-decoration: solid #ff4088 underline 3px;
     text-underline-offset: 3px;
     user-select: none;
+  }
+
+  .slot {
+    display: flex;
+    flex: 1;
+    justify-content: flex-end;
   }
 
   .preferences {
@@ -58,6 +63,9 @@
     class="treetop"
     transition:fly={{ y: -72, duration: 1200, easing: elasticOut, opacity: 1 }}>
     Treetop
+  </div>
+  <div class="slot">
+    <slot />
   </div>
   <div>
     <div class="preferences">

--- a/src/treetop/types.ts
+++ b/src/treetop/types.ts
@@ -38,6 +38,9 @@ export type NodeStoreMap = Map<string, Writable<FolderNode>>;
 // Provides access to the last visit times of bookmarks.
 export type LastVisitTimeMap = Map<string, Writable<number>>;
 
+// Set of node IDs that match the active filter.
+export type FilterSet = Writable<Set<string>>;
+
 // Changes to a bookmark's properties
 export interface PropertiesChanges {
   title: string;

--- a/src/welcome/Welcome.svelte
+++ b/src/welcome/Welcome.svelte
@@ -100,8 +100,9 @@
   </InfoBox>
 
   <InfoBox>
-    <span slot="title">Edit your bookmarks</span>
-    <span slot="detail1">
+    <span slot="title">Find and edit your bookmarks</span>
+    <span slot="detail1">Search for bookmarks by name or URL.</span>
+    <span slot="detail2">
       Right-click to edit or delete bookmarks and folders.
     </span>
   </InfoBox>

--- a/test/treetop/FilterInput.svelte.test.ts
+++ b/test/treetop/FilterInput.svelte.test.ts
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import faker from 'faker';
+
+import FilterInput from '@Treetop/treetop/FilterInput.svelte';
+
+const setup = () => {
+  return render(FilterInput);
+};
+
+beforeEach(() => {
+  jest.useFakeTimers('modern');
+
+  mockBrowser.i18n.getMessage.expect('search').andReturn('Search');
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+it('renders filter input', () => {
+  setup();
+
+  expect(screen.getByLabelText(/^search$/i)).toBeInTheDocument();
+});
+
+it('dispatches input event when text is typed after debouncing', () => {
+  const { component } = setup();
+
+  const callback = jest.fn();
+  component.$on('input', callback);
+
+  const input = screen.getByLabelText(/^search$/i);
+
+  const words = faker.random.words();
+  userEvent.type(input, words);
+
+  expect(callback).not.toHaveBeenCalled();
+  jest.runAllTimers();
+  expect(callback).toHaveBeenCalledTimes(1);
+
+  // FIXME: Check event properties
+  // https://github.com/sveltejs/svelte/issues/3119
+
+  userEvent.type(input, '{backspace}');
+
+  expect(callback).toHaveBeenCalledTimes(1);
+  jest.runAllTimers();
+  expect(callback).toHaveBeenCalledTimes(2);
+
+  userEvent.clear(input);
+
+  expect(callback).toHaveBeenCalledTimes(2);
+  jest.runAllTimers();
+  expect(callback).toHaveBeenCalledTimes(3);
+});
+
+it('dispatches input event when enter is pressed', () => {
+  const { component } = setup();
+
+  const callback = jest.fn();
+  component.$on('input', callback);
+
+  const input = screen.getByLabelText(/^search$/i);
+
+  const words = faker.random.words();
+  userEvent.type(input, `${words}{enter}`);
+
+  // Check that the event fired immediately
+  // FIXME: Check event properties
+  // https://github.com/sveltejs/svelte/issues/3119
+  expect(callback).toHaveBeenCalledTimes(1);
+
+  // Check that the debounce was cancelled and the event didn't fire a second
+  // time
+  jest.runAllTimers();
+  expect(callback).toHaveBeenCalledTimes(1);
+});

--- a/test/treetop/FilterManager.test.ts
+++ b/test/treetop/FilterManager.test.ts
@@ -1,0 +1,1460 @@
+/* eslint no-irregular-whitespace: ["error", { "skipComments": true }] */
+
+import { get, writable } from 'svelte/store';
+import faker from 'faker';
+
+import { FilterManager } from '@Treetop/treetop/FilterManager';
+import type * as Treetop from '@Treetop/treetop/types';
+
+import {
+  createBookmarkNode,
+  createBrowserBookmarkNode,
+  createBrowserFolderNode,
+  createBrowserSeparatorNode,
+  createFolderNode,
+  createOtherBookmarksNode,
+  createSeparatorNode,
+} from '../utils/factories';
+
+const NUM_RANDOM_WORDS = 3;
+
+// Generate a random string that contains the specified string.
+const randomStringContaining = (str: string) => {
+  return `${faker.random.words(NUM_RANDOM_WORDS)}${str}${faker.random.words(
+    NUM_RANDOM_WORDS
+  )}`;
+};
+
+let nodeStoreMap: Treetop.NodeStoreMap;
+let fs: Treetop.FilterSet;
+let filterManager: FilterManager;
+let folderNode1: Treetop.FolderNode;
+let folderNode2: Treetop.FolderNode;
+let folderNode3: Treetop.FolderNode;
+let folderNode4: Treetop.FolderNode;
+let folderNode5: Treetop.FolderNode;
+let folderNode6: Treetop.FolderNode;
+
+beforeEach(() => {
+  nodeStoreMap = new Map() as Treetop.NodeStoreMap;
+  fs = writable(new Set<string>());
+  filterManager = new FilterManager(fs, nodeStoreMap);
+
+  // Create node tree:
+  // folderNode1
+  //   ├── bookmarkNode
+  //   ├── bookmarkNode
+  //   ├── bookmarkNode
+  //   ├── separatorNode
+  //   ├── folderNode2
+  //   │  ├── bookmarkNode
+  //   │  ├── bookmarkNode
+  //   │  ├── bookmarkNode
+  //   │  ├── folderNode3
+  //   │  │  ├── bookmarkNode
+  //   │  │  ├── bookmarkNode
+  //   │  │  └── bookmarkNode
+  //   │  └── folderNode4
+  //   │     ├── bookmarkNode
+  //   │     ├── bookmarkNode
+  //   │     └── bookmarkNode
+  //   └── folderNode5
+  //      ├── bookmarkNode
+  //      ├── bookmarkNode
+  //      └── folderNode6
+  //         ├── bookmarkNode
+  //         └── bookmarkNode
+
+  folderNode1 = createFolderNode({
+    children: [
+      createBookmarkNode(),
+      createBookmarkNode(),
+      createBookmarkNode(),
+      createSeparatorNode(),
+    ],
+  });
+
+  folderNode2 = createFolderNode({
+    parentId: folderNode1.id,
+    children: [
+      createBookmarkNode(),
+      createBookmarkNode(),
+      createBookmarkNode(),
+    ],
+  });
+  folderNode1.children.push(folderNode2);
+
+  folderNode3 = createFolderNode({
+    parentId: folderNode2.id,
+    children: [
+      createBookmarkNode(),
+      createBookmarkNode(),
+      createBookmarkNode(),
+    ],
+  });
+  folderNode2.children.push(folderNode3);
+
+  folderNode4 = createFolderNode({
+    parentId: folderNode2.id,
+    children: [
+      createBookmarkNode(),
+      createBookmarkNode(),
+      createBookmarkNode(),
+    ],
+  });
+  folderNode2.children.push(folderNode4);
+
+  folderNode5 = createFolderNode({
+    parentId: folderNode1.id,
+    children: [createBookmarkNode(), createBookmarkNode()],
+  });
+  folderNode1.children.push(folderNode5);
+
+  folderNode6 = createFolderNode({
+    parentId: folderNode5.id,
+    children: [createBookmarkNode(), createBookmarkNode()],
+  });
+  folderNode5.children.push(folderNode6);
+
+  nodeStoreMap.set(folderNode1.id, writable(folderNode1));
+  nodeStoreMap.set(folderNode2.id, writable(folderNode2));
+  nodeStoreMap.set(folderNode3.id, writable(folderNode3));
+  nodeStoreMap.set(folderNode4.id, writable(folderNode4));
+  nodeStoreMap.set(folderNode5.id, writable(folderNode5));
+  nodeStoreMap.set(folderNode6.id, writable(folderNode6));
+});
+
+describe('setFilter', () => {
+  it('no matches', () => {
+    filterManager.setFilter(faker.random.words(NUM_RANDOM_WORDS));
+
+    const filterSet = get(fs);
+    expect(filterSet.size).toBe(0);
+  });
+
+  it('match in root folder', () => {
+    const filter = (folderNode1.children[1] as Treetop.BookmarkNode).title;
+    filterManager.setFilter(filter);
+
+    const filterSet = get(fs);
+    expect(filterSet.size).toBe(2);
+    expect(filterSet.has(folderNode1.id)).toBe(true);
+    expect(filterSet.has(folderNode1.children[1].id)).toBe(true);
+  });
+
+  it('URL match in root folder', () => {
+    const url = (folderNode1.children[1] as Treetop.BookmarkNode).url;
+    const filter = new URL(url).hostname;
+    filterManager.setFilter(filter);
+
+    const filterSet = get(fs);
+    expect(filterSet.size).toBe(2);
+    expect(filterSet.has(folderNode1.id)).toBe(true);
+    expect(filterSet.has(folderNode1.children[1].id)).toBe(true);
+  });
+
+  it('multiple matches in root folder', () => {
+    const filter = faker.random.words(NUM_RANDOM_WORDS);
+    (folderNode1
+      .children[0] as Treetop.BookmarkNode).title = randomStringContaining(
+      filter
+    );
+    (folderNode1
+      .children[1] as Treetop.BookmarkNode).title = randomStringContaining(
+      filter
+    );
+    filterManager.setFilter(filter);
+
+    const filterSet = get(fs);
+    expect(filterSet.size).toBe(3);
+    expect(filterSet.has(folderNode1.id)).toBe(true);
+    expect(filterSet.has(folderNode1.children[0].id)).toBe(true);
+    expect(filterSet.has(folderNode1.children[1].id)).toBe(true);
+  });
+
+  it('match in root folder and in nested folder', () => {
+    const filter = faker.random.words(NUM_RANDOM_WORDS);
+    (folderNode1
+      .children[1] as Treetop.BookmarkNode).title = randomStringContaining(
+      filter
+    );
+    (folderNode2
+      .children[1] as Treetop.BookmarkNode).title = randomStringContaining(
+      filter
+    );
+    filterManager.setFilter(filter);
+
+    const filterSet = get(fs);
+    expect(filterSet.size).toBe(4);
+    expect(filterSet.has(folderNode1.id)).toBe(true);
+    expect(filterSet.has(folderNode2.id)).toBe(true);
+    expect(filterSet.has(folderNode1.children[1].id)).toBe(true);
+    expect(filterSet.has(folderNode2.children[1].id)).toBe(true);
+  });
+
+  it('match in nested folder', () => {
+    const filter = (folderNode2.children[1] as Treetop.BookmarkNode).title;
+    filterManager.setFilter(filter);
+
+    const filterSet = get(fs);
+    expect(filterSet.size).toBe(3);
+    expect(filterSet.has(folderNode1.id)).toBe(true);
+    expect(filterSet.has(folderNode2.id)).toBe(true);
+    expect(filterSet.has(folderNode2.children[1].id)).toBe(true);
+  });
+
+  it('multiple matches in nested folder', () => {
+    const filter = faker.random.words(NUM_RANDOM_WORDS);
+    (folderNode2
+      .children[0] as Treetop.BookmarkNode).title = randomStringContaining(
+      filter
+    );
+    (folderNode2
+      .children[1] as Treetop.BookmarkNode).title = randomStringContaining(
+      filter
+    );
+    filterManager.setFilter(filter);
+
+    const filterSet = get(fs);
+    expect(filterSet.size).toBe(4);
+    expect(filterSet.has(folderNode1.id)).toBe(true);
+    expect(filterSet.has(folderNode2.id)).toBe(true);
+    expect(filterSet.has(folderNode2.children[0].id)).toBe(true);
+    expect(filterSet.has(folderNode2.children[1].id)).toBe(true);
+  });
+
+  it('match in deeply nested folder', () => {
+    const filter = (folderNode4.children[1] as Treetop.BookmarkNode).title;
+    filterManager.setFilter(filter);
+
+    const filterSet = get(fs);
+    expect(filterSet.size).toBe(4);
+    expect(filterSet.has(folderNode1.id)).toBe(true);
+    expect(filterSet.has(folderNode2.id)).toBe(true);
+    expect(filterSet.has(folderNode4.id)).toBe(true);
+    expect(filterSet.has(folderNode4.children[1].id)).toBe(true);
+  });
+
+  it('multiple matches in deeply nested folder', () => {
+    const filter = faker.random.words(NUM_RANDOM_WORDS);
+    (folderNode4
+      .children[0] as Treetop.BookmarkNode).title = randomStringContaining(
+      filter
+    );
+    (folderNode4
+      .children[2] as Treetop.BookmarkNode).title = randomStringContaining(
+      filter
+    );
+    filterManager.setFilter(filter);
+
+    const filterSet = get(fs);
+    expect(filterSet.size).toBe(5);
+    expect(filterSet.has(folderNode1.id)).toBe(true);
+    expect(filterSet.has(folderNode2.id)).toBe(true);
+    expect(filterSet.has(folderNode4.id)).toBe(true);
+    expect(filterSet.has(folderNode4.children[0].id)).toBe(true);
+    expect(filterSet.has(folderNode4.children[2].id)).toBe(true);
+  });
+
+  it('matches in multiple nested folders', () => {
+    const filter = faker.random.words(NUM_RANDOM_WORDS);
+    (folderNode2
+      .children[0] as Treetop.BookmarkNode).title = randomStringContaining(
+      filter
+    );
+    (folderNode6
+      .children[0] as Treetop.BookmarkNode).title = randomStringContaining(
+      filter
+    );
+    filterManager.setFilter(filter);
+
+    const filterSet = get(fs);
+    expect(filterSet.size).toBe(6);
+    expect(filterSet.has(folderNode1.id)).toBe(true);
+    expect(filterSet.has(folderNode2.id)).toBe(true);
+    expect(filterSet.has(folderNode5.id)).toBe(true);
+    expect(filterSet.has(folderNode6.id)).toBe(true);
+    expect(filterSet.has(folderNode2.children[0].id)).toBe(true);
+    expect(filterSet.has(folderNode6.children[0].id)).toBe(true);
+  });
+});
+
+describe('handleBookmarkCreated', () => {
+  describe('when filter is set', () => {
+    it('new matching bookmark in root folder', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      filterManager.setFilter(filter);
+
+      const baseNode = createOtherBookmarksNode();
+      baseNode.id = folderNode1.id;
+
+      const bookmarkNode = createBrowserBookmarkNode(baseNode);
+      bookmarkNode.title += filter;
+
+      filterManager.handleBookmarkCreated(bookmarkNode.id, bookmarkNode);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(baseNode.id)).toBe(true);
+      expect(filterSet.size).toBe(2);
+    });
+
+    it('new matching bookmark URL in root folder', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      filterManager.setFilter(filter);
+
+      const baseNode = createOtherBookmarksNode();
+      baseNode.id = folderNode1.id;
+
+      const bookmarkNode = createBrowserBookmarkNode(baseNode);
+      bookmarkNode.url += filter;
+
+      filterManager.handleBookmarkCreated(bookmarkNode.id, bookmarkNode);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(baseNode.id)).toBe(true);
+      expect(filterSet.size).toBe(2);
+    });
+
+    it('new non-matching bookmark in root folder', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      filterManager.setFilter(filter);
+
+      const baseNode = createOtherBookmarksNode();
+      baseNode.id = folderNode1.id;
+
+      const bookmarkNode = createBrowserBookmarkNode(baseNode);
+
+      filterManager.handleBookmarkCreated(bookmarkNode.id, bookmarkNode);
+
+      const filterSet = get(fs);
+      expect(filterSet.size).toBe(0);
+    });
+
+    it('new matching bookmark in nested folder', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      filterManager.setFilter(filter);
+
+      const baseNode = createOtherBookmarksNode();
+      baseNode.id = folderNode1.id;
+
+      const folderNode = createBrowserFolderNode(baseNode);
+      folderNode.id = folderNode2.id;
+
+      const bookmarkNode = createBrowserBookmarkNode(folderNode);
+      bookmarkNode.title += filter;
+
+      filterManager.handleBookmarkCreated(bookmarkNode.id, bookmarkNode);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode.id)).toBe(true);
+      expect(filterSet.has(baseNode.id)).toBe(true);
+      expect(filterSet.size).toBe(3);
+    });
+
+    it('new non-matching bookmark in nested folder', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      filterManager.setFilter(filter);
+
+      const baseNode = createOtherBookmarksNode();
+      baseNode.id = folderNode1.id;
+
+      const folderNode = createBrowserFolderNode(baseNode);
+      folderNode.id = folderNode2.id;
+
+      const bookmarkNode = createBrowserBookmarkNode(folderNode);
+
+      filterManager.handleBookmarkCreated(bookmarkNode.id, bookmarkNode);
+
+      const filterSet = get(fs);
+      expect(filterSet.size).toBe(0);
+    });
+
+    it('ignores new folders', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      filterManager.setFilter(filter);
+
+      const baseNode = createOtherBookmarksNode();
+      const folderNode = createBrowserFolderNode(baseNode);
+      folderNode.title = filter;
+
+      filterManager.handleBookmarkCreated(folderNode.id, folderNode);
+
+      const filterSet = get(fs);
+      expect(filterSet.size).toBe(0);
+    });
+
+    it('ignores new separators', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      filterManager.setFilter(filter);
+
+      const baseNode = createOtherBookmarksNode();
+      const separatorNode = createBrowserSeparatorNode(baseNode);
+
+      filterManager.handleBookmarkCreated(separatorNode.id, separatorNode);
+
+      const filterSet = get(fs);
+      expect(filterSet.size).toBe(0);
+    });
+  });
+
+  describe('when filter is not set', () => {
+    it('ignores new bookmarks', () => {
+      const baseNode = createOtherBookmarksNode();
+      const bookmarkNode = createBrowserBookmarkNode(baseNode);
+
+      filterManager.handleBookmarkCreated(bookmarkNode.id, bookmarkNode);
+
+      const filterSet = get(fs);
+      expect(filterSet.size).toBe(0);
+    });
+
+    it('ignores new folders', () => {
+      const baseNode = createOtherBookmarksNode();
+      const folderNode = createBrowserFolderNode(baseNode);
+
+      filterManager.handleBookmarkCreated(folderNode.id, folderNode);
+
+      const filterSet = get(fs);
+      expect(filterSet.size).toBe(0);
+    });
+
+    it('ignores new separators', () => {
+      const baseNode = createOtherBookmarksNode();
+      const separatorNode = createBrowserSeparatorNode(baseNode);
+
+      filterManager.handleBookmarkCreated(separatorNode.id, separatorNode);
+
+      const filterSet = get(fs);
+      expect(filterSet.size).toBe(0);
+    });
+  });
+});
+
+describe('handleBookmarkRemoved', () => {
+  describe('when filter is set', () => {
+    it('removed matching bookmark in root folder', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode = folderNode1.children[0] as Treetop.BookmarkNode;
+      bookmarkNode.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.size).toBe(2);
+
+      folderNode1.children = folderNode1.children.filter(
+        (child) => child.id !== bookmarkNode.id
+      );
+
+      filterManager.handleBookmarkRemoved(bookmarkNode.id);
+
+      expect(filterSet.size).toBe(0);
+    });
+
+    it('removed matching bookmark in root folder when sibling bookmark matches', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode1 = folderNode1.children[0] as Treetop.BookmarkNode;
+      const bookmarkNode2 = folderNode1.children[1] as Treetop.BookmarkNode;
+      bookmarkNode1.title += filter;
+      bookmarkNode2.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode1.id)).toBe(true);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.size).toBe(3);
+
+      folderNode1.children = folderNode1.children.filter(
+        (child) => child.id !== bookmarkNode1.id
+      );
+
+      filterManager.handleBookmarkRemoved(bookmarkNode1.id);
+
+      expect(filterSet.has(bookmarkNode1.id)).toBe(false);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.size).toBe(2);
+    });
+
+    it('removed matching bookmark in root folder when nested bookmark matches', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode1 = folderNode1.children[0] as Treetop.BookmarkNode;
+      const bookmarkNode2 = folderNode2.children[0] as Treetop.BookmarkNode;
+      bookmarkNode1.title += filter;
+      bookmarkNode2.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode1.id)).toBe(true);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.size).toBe(4);
+
+      folderNode1.children = folderNode1.children.filter(
+        (child) => child.id !== bookmarkNode1.id
+      );
+
+      filterManager.handleBookmarkRemoved(bookmarkNode1.id);
+
+      expect(filterSet.has(bookmarkNode1.id)).toBe(false);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.size).toBe(3);
+    });
+
+    it('removed matching bookmark in nested folder', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode = folderNode3.children[0] as Treetop.BookmarkNode;
+      bookmarkNode.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode3.id)).toBe(true);
+      expect(filterSet.size).toBe(4);
+
+      folderNode3.children = folderNode3.children.filter(
+        (child) => child.id !== bookmarkNode.id
+      );
+
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode3.id)).toBe(true);
+      expect(filterSet.size).toBe(4);
+
+      filterManager.handleBookmarkRemoved(bookmarkNode.id);
+
+      expect(filterSet.size).toBe(0);
+    });
+
+    it('removed matching bookmark in nested folder when sibling bookmark matches', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode1 = folderNode2.children[0] as Treetop.BookmarkNode;
+      const bookmarkNode2 = folderNode2.children[1] as Treetop.BookmarkNode;
+      bookmarkNode1.title += filter;
+      bookmarkNode2.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode1.id)).toBe(true);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.size).toBe(4);
+
+      folderNode2.children = folderNode2.children.filter(
+        (child) => child.id !== bookmarkNode1.id
+      );
+
+      filterManager.handleBookmarkRemoved(bookmarkNode1.id);
+
+      expect(filterSet.has(bookmarkNode1.id)).toBe(false);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.size).toBe(3);
+    });
+
+    it('removed matching bookmark in nested folder when nested bookmark matches', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode1 = folderNode2.children[0] as Treetop.BookmarkNode;
+      const bookmarkNode2 = folderNode3.children[0] as Treetop.BookmarkNode;
+      bookmarkNode1.title += filter;
+      bookmarkNode2.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode1.id)).toBe(true);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode3.id)).toBe(true);
+      expect(filterSet.size).toBe(5);
+
+      folderNode2.children = folderNode2.children.filter(
+        (child) => child.id !== bookmarkNode1.id
+      );
+
+      filterManager.handleBookmarkRemoved(bookmarkNode1.id);
+
+      expect(filterSet.has(bookmarkNode1.id)).toBe(false);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode3.id)).toBe(true);
+      expect(filterSet.size).toBe(4);
+    });
+
+    it('removed non-matching bookmark in root folder', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode = folderNode1.children[0] as Treetop.BookmarkNode;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.size).toBe(0);
+
+      folderNode1.children = folderNode1.children.filter(
+        (child) => child.id !== bookmarkNode.id
+      );
+
+      filterManager.handleBookmarkRemoved(bookmarkNode.id);
+
+      expect(filterSet.size).toBe(0);
+    });
+
+    it('removed non-matching bookmark in nested folder', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode = folderNode2.children[0] as Treetop.BookmarkNode;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.size).toBe(0);
+
+      folderNode2.children = folderNode2.children.filter(
+        (child) => child.id !== bookmarkNode.id
+      );
+
+      filterManager.handleBookmarkRemoved(bookmarkNode.id);
+
+      expect(filterSet.size).toBe(0);
+    });
+
+    it('removed folder containing a matching bookmark', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode = folderNode4.children[0] as Treetop.BookmarkNode;
+      bookmarkNode.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode4.id)).toBe(true);
+      expect(filterSet.size).toBe(4);
+
+      const removedNodeIds = [
+        folderNode4.id,
+        ...folderNode4.children.map((node) => node.id),
+      ];
+      folderNode4.children = [];
+
+      filterManager.beginBatchRemove();
+      removedNodeIds.forEach((nodeId) =>
+        filterManager.handleBookmarkRemoved(nodeId)
+      );
+      filterManager.endBatchRemove();
+
+      expect(filterSet.size).toBe(0);
+    });
+
+    it('removed folder not containing a matching bookmark', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.size).toBe(0);
+
+      const removedNodeIds = [
+        folderNode4.id,
+        ...folderNode4.children.map((node) => node.id),
+      ];
+      folderNode4.children = [];
+
+      filterManager.beginBatchRemove();
+      removedNodeIds.forEach((nodeId) =>
+        filterManager.handleBookmarkRemoved(nodeId)
+      );
+      filterManager.endBatchRemove();
+
+      expect(filterSet.size).toBe(0);
+    });
+  });
+
+  describe('when filter is not set', () => {
+    it('ignores bookmarks', () => {
+      const baseNode = createOtherBookmarksNode();
+      const bookmarkNode = createBrowserBookmarkNode(baseNode);
+      filterManager.handleBookmarkRemoved(bookmarkNode.id);
+
+      const filterSet = get(fs);
+      expect(filterSet.size).toBe(0);
+    });
+
+    it('ignores folders', () => {
+      const baseNode = createOtherBookmarksNode();
+      const folderNode = createBrowserFolderNode(baseNode);
+      filterManager.handleBookmarkRemoved(folderNode.id);
+
+      const filterSet = get(fs);
+      expect(filterSet.size).toBe(0);
+    });
+
+    it('ignores separators', () => {
+      const baseNode = createOtherBookmarksNode();
+      const separatorNode = createBrowserSeparatorNode(baseNode);
+      filterManager.handleBookmarkRemoved(separatorNode.id);
+
+      const filterSet = get(fs);
+      expect(filterSet.size).toBe(0);
+    });
+  });
+});
+
+describe('handleBookmarkChanged', () => {
+  describe('when filter is set', () => {
+    it('non-matching bookmark title now matches', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.size).toBe(0);
+
+      const bookmarkNode = folderNode2.children[0] as Treetop.BookmarkNode;
+      bookmarkNode.title += filter;
+
+      const changeInfo: browser.bookmarks._OnChangedChangeInfo = {
+        title: bookmarkNode.title,
+      };
+      filterManager.handleBookmarkChanged(bookmarkNode.id, changeInfo);
+
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.size).toBe(3);
+    });
+
+    it('non-matching bookmark URL now matches', () => {
+      const filter = faker.random.alphaNumeric(8);
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.size).toBe(0);
+
+      const bookmarkNode = folderNode2.children[0] as Treetop.BookmarkNode;
+      bookmarkNode.url += filter;
+
+      const changeInfo: browser.bookmarks._OnChangedChangeInfo = {
+        title: bookmarkNode.title,
+        url: bookmarkNode.url,
+      };
+      filterManager.handleBookmarkChanged(bookmarkNode.id, changeInfo);
+
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.size).toBe(3);
+    });
+
+    it('non-matching bookmark title now matches when sibling matches', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode1 = folderNode2.children[0] as Treetop.BookmarkNode;
+      const bookmarkNode2 = folderNode2.children[1] as Treetop.BookmarkNode;
+      bookmarkNode2.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode1.id)).toBe(false);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.size).toBe(3);
+
+      bookmarkNode1.title += filter;
+
+      const changeInfo: browser.bookmarks._OnChangedChangeInfo = {
+        title: bookmarkNode1.title,
+      };
+      filterManager.handleBookmarkChanged(bookmarkNode1.id, changeInfo);
+
+      expect(filterSet.has(bookmarkNode1.id)).toBe(true);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.size).toBe(4);
+    });
+
+    it('non-matching bookmark title now matches when nested bookmark matches', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode1 = folderNode2.children[0] as Treetop.BookmarkNode;
+      const bookmarkNode2 = folderNode3.children[1] as Treetop.BookmarkNode;
+      bookmarkNode2.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode1.id)).toBe(false);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode3.id)).toBe(true);
+      expect(filterSet.size).toBe(4);
+
+      bookmarkNode1.title += filter;
+
+      const changeInfo: browser.bookmarks._OnChangedChangeInfo = {
+        title: bookmarkNode1.title,
+      };
+      filterManager.handleBookmarkChanged(bookmarkNode1.id, changeInfo);
+
+      expect(filterSet.has(bookmarkNode1.id)).toBe(true);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode3.id)).toBe(true);
+      expect(filterSet.size).toBe(5);
+    });
+
+    it('previously matching bookmark title no longer matches', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode = folderNode2.children[0] as Treetop.BookmarkNode;
+      bookmarkNode.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.size).toBe(3);
+
+      bookmarkNode.title = bookmarkNode.title.replace(
+        filter,
+        faker.random.word()
+      );
+
+      const changeInfo: browser.bookmarks._OnChangedChangeInfo = {
+        title: bookmarkNode.title,
+      };
+      filterManager.handleBookmarkChanged(bookmarkNode.id, changeInfo);
+
+      expect(filterSet.size).toBe(0);
+    });
+
+    it('previously matching bookmark URL no longer matches', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode = folderNode2.children[0] as Treetop.BookmarkNode;
+      bookmarkNode.url += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.size).toBe(3);
+
+      bookmarkNode.url = bookmarkNode.url.replace(filter, faker.random.word());
+
+      const changeInfo: browser.bookmarks._OnChangedChangeInfo = {
+        title: bookmarkNode.title,
+        url: bookmarkNode.url,
+      };
+      filterManager.handleBookmarkChanged(bookmarkNode.id, changeInfo);
+
+      expect(filterSet.size).toBe(0);
+    });
+
+    it('previously matching bookmark no longer matches when sibling matches', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode1 = folderNode2.children[0] as Treetop.BookmarkNode;
+      const bookmarkNode2 = folderNode2.children[1] as Treetop.BookmarkNode;
+      bookmarkNode1.title += filter;
+      bookmarkNode2.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode1.id)).toBe(true);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.size).toBe(4);
+
+      bookmarkNode1.title = bookmarkNode1.title.replace(
+        filter,
+        faker.random.word()
+      );
+
+      const changeInfo: browser.bookmarks._OnChangedChangeInfo = {
+        title: bookmarkNode1.title,
+      };
+      filterManager.handleBookmarkChanged(bookmarkNode1.id, changeInfo);
+
+      expect(filterSet.has(bookmarkNode1.id)).toBe(false);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.size).toBe(3);
+    });
+
+    it('previously matching bookmark no longer matches when nested bookmark matches', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode1 = folderNode2.children[0] as Treetop.BookmarkNode;
+      const bookmarkNode2 = folderNode3.children[0] as Treetop.BookmarkNode;
+      bookmarkNode1.title += filter;
+      bookmarkNode2.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode1.id)).toBe(true);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode3.id)).toBe(true);
+      expect(filterSet.size).toBe(5);
+
+      bookmarkNode1.title = bookmarkNode1.title.replace(
+        filter,
+        faker.random.word()
+      );
+
+      const changeInfo: browser.bookmarks._OnChangedChangeInfo = {
+        title: bookmarkNode1.title,
+      };
+      filterManager.handleBookmarkChanged(bookmarkNode1.id, changeInfo);
+
+      expect(filterSet.has(bookmarkNode1.id)).toBe(false);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode3.id)).toBe(true);
+      expect(filterSet.size).toBe(4);
+    });
+  });
+
+  describe('when filter is not set', () => {
+    it('ignores bookmarks', () => {
+      const bookmarkNode = folderNode1.children[0] as Treetop.BookmarkNode;
+      const changeInfo: browser.bookmarks._OnChangedChangeInfo = {
+        title: faker.random.words(),
+      };
+      filterManager.handleBookmarkChanged(bookmarkNode.id, changeInfo);
+
+      const filterSet = get(fs);
+      expect(filterSet.size).toBe(0);
+    });
+
+    it('ignores folders', () => {
+      const changeInfo: browser.bookmarks._OnChangedChangeInfo = {
+        title: faker.random.words(),
+      };
+      filterManager.handleBookmarkChanged(folderNode2.id, changeInfo);
+
+      const filterSet = get(fs);
+      expect(filterSet.size).toBe(0);
+    });
+  });
+});
+
+describe('handleBookmarkMoved', () => {
+  describe('when filter is set', () => {
+    it('moved within folder', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode1 = folderNode2.children[0] as Treetop.BookmarkNode;
+      const bookmarkNode2 = folderNode2.children[1] as Treetop.BookmarkNode;
+      bookmarkNode1.title += filter;
+      bookmarkNode2.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode1.id)).toBe(true);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.size).toBe(4);
+
+      // Move bookmarkNode2 to index 0
+      const children = folderNode2.children;
+      [children[0], children[1]] = [children[1], children[0]];
+
+      const moveInfo: browser.bookmarks._OnMovedMoveInfo = {
+        parentId: bookmarkNode2.parentId!,
+        index: 0,
+        oldParentId: bookmarkNode2.parentId!,
+        oldIndex: 1,
+      };
+
+      filterManager.handleBookmarkMoved(bookmarkNode2.id, moveInfo);
+
+      expect(filterSet.has(bookmarkNode1.id)).toBe(true);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.size).toBe(4);
+    });
+
+    it('moved to parent folder', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode = folderNode3.children[0] as Treetop.BookmarkNode;
+      bookmarkNode.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode3.id)).toBe(true);
+      expect(filterSet.size).toBe(4);
+
+      // Move bookmarkNode to parent folder
+      folderNode2.children.unshift(bookmarkNode);
+      folderNode3.children = folderNode3.children.filter(
+        (node) => node.id !== bookmarkNode.id
+      );
+
+      const moveInfo: browser.bookmarks._OnMovedMoveInfo = {
+        parentId: folderNode3.id,
+        index: 0,
+        oldParentId: folderNode2.id,
+        oldIndex: 0,
+      };
+
+      filterManager.handleBookmarkMoved(bookmarkNode.id, moveInfo);
+
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.size).toBe(3);
+    });
+
+    it('moved to parent folder when sibling matches', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode1 = folderNode3.children[0] as Treetop.BookmarkNode;
+      const bookmarkNode2 = folderNode3.children[1] as Treetop.BookmarkNode;
+      bookmarkNode1.title += filter;
+      bookmarkNode2.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode1.id)).toBe(true);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode3.id)).toBe(true);
+      expect(filterSet.size).toBe(5);
+
+      // Move bookmarkNode2 to parent folder
+      folderNode2.children.unshift(bookmarkNode2);
+      folderNode3.children = folderNode3.children.filter(
+        (node) => node.id !== bookmarkNode2.id
+      );
+
+      const moveInfo: browser.bookmarks._OnMovedMoveInfo = {
+        parentId: folderNode3.id,
+        index: 0,
+        oldParentId: folderNode2.id,
+        oldIndex: 1,
+      };
+
+      filterManager.handleBookmarkMoved(bookmarkNode2.id, moveInfo);
+
+      expect(filterSet.has(bookmarkNode1.id)).toBe(true);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode3.id)).toBe(true);
+      expect(filterSet.size).toBe(5);
+    });
+
+    it('moved to child folder', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode = folderNode2.children[0] as Treetop.BookmarkNode;
+      bookmarkNode.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.size).toBe(3);
+
+      // Move bookmarkNode to child folder
+      folderNode4.children.unshift(bookmarkNode);
+      folderNode2.children = folderNode2.children.filter(
+        (node) => node.id !== bookmarkNode.id
+      );
+
+      const moveInfo: browser.bookmarks._OnMovedMoveInfo = {
+        parentId: folderNode4.id,
+        index: 0,
+        oldParentId: folderNode2.id,
+        oldIndex: 0,
+      };
+
+      filterManager.handleBookmarkMoved(bookmarkNode.id, moveInfo);
+
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode4.id)).toBe(true);
+      expect(filterSet.size).toBe(4);
+    });
+
+    it('moved to child folder when sibling matches', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode1 = folderNode2.children[0] as Treetop.BookmarkNode;
+      const bookmarkNode2 = folderNode2.children[1] as Treetop.BookmarkNode;
+      bookmarkNode1.title += filter;
+      bookmarkNode2.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode1.id)).toBe(true);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.size).toBe(4);
+
+      // Move bookmarkNode2 to child folder
+      folderNode4.children.unshift(bookmarkNode2);
+      folderNode2.children = folderNode2.children.filter(
+        (node) => node.id !== bookmarkNode2.id
+      );
+
+      const moveInfo: browser.bookmarks._OnMovedMoveInfo = {
+        parentId: folderNode4.id,
+        index: 0,
+        oldParentId: folderNode2.id,
+        oldIndex: 1,
+      };
+
+      filterManager.handleBookmarkMoved(bookmarkNode2.id, moveInfo);
+
+      expect(filterSet.has(bookmarkNode1.id)).toBe(true);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode4.id)).toBe(true);
+      expect(filterSet.size).toBe(5);
+    });
+
+    it('moved to sibling folder', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode = folderNode2.children[0] as Treetop.BookmarkNode;
+      bookmarkNode.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.size).toBe(3);
+
+      // Move bookmarkNode to sibling folder
+      folderNode5.children.unshift(bookmarkNode);
+      folderNode2.children = folderNode2.children.filter(
+        (node) => node.id !== bookmarkNode.id
+      );
+
+      const moveInfo: browser.bookmarks._OnMovedMoveInfo = {
+        parentId: folderNode5.id,
+        index: 0,
+        oldParentId: folderNode2.id,
+        oldIndex: 0,
+      };
+
+      filterManager.handleBookmarkMoved(bookmarkNode.id, moveInfo);
+
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode5.id)).toBe(true);
+      expect(filterSet.size).toBe(3);
+    });
+
+    it('moved to sibling folder when sibling matches', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode1 = folderNode2.children[0] as Treetop.BookmarkNode;
+      const bookmarkNode2 = folderNode2.children[1] as Treetop.BookmarkNode;
+      bookmarkNode1.title += filter;
+      bookmarkNode2.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode1.id)).toBe(true);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.size).toBe(4);
+
+      // Move bookmarkNode2 to sibling folder
+      folderNode5.children.unshift(bookmarkNode2);
+      folderNode2.children = folderNode2.children.filter(
+        (node) => node.id !== bookmarkNode2.id
+      );
+
+      const moveInfo: browser.bookmarks._OnMovedMoveInfo = {
+        parentId: folderNode5.id,
+        index: 0,
+        oldParentId: folderNode2.id,
+        oldIndex: 0,
+      };
+
+      filterManager.handleBookmarkMoved(bookmarkNode2.id, moveInfo);
+
+      expect(filterSet.has(bookmarkNode1.id)).toBe(true);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode5.id)).toBe(true);
+      expect(filterSet.size).toBe(5);
+    });
+
+    it('moved to distant folder', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode = folderNode3.children[0] as Treetop.BookmarkNode;
+      bookmarkNode.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode3.id)).toBe(true);
+      expect(filterSet.size).toBe(4);
+
+      // Move bookmarkNode to distant folder
+      folderNode6.children.unshift(bookmarkNode);
+      folderNode3.children = folderNode3.children.filter(
+        (node) => node.id !== bookmarkNode.id
+      );
+
+      const moveInfo: browser.bookmarks._OnMovedMoveInfo = {
+        parentId: folderNode6.id,
+        index: 0,
+        oldParentId: folderNode3.id,
+        oldIndex: 0,
+      };
+
+      filterManager.handleBookmarkMoved(bookmarkNode.id, moveInfo);
+
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode5.id)).toBe(true);
+      expect(filterSet.has(folderNode6.id)).toBe(true);
+      expect(filterSet.size).toBe(4);
+    });
+
+    it('moved to distant folder when sibling matches', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode1 = folderNode3.children[0] as Treetop.BookmarkNode;
+      const bookmarkNode2 = folderNode3.children[1] as Treetop.BookmarkNode;
+      bookmarkNode1.title += filter;
+      bookmarkNode2.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode1.id)).toBe(true);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode3.id)).toBe(true);
+      expect(filterSet.size).toBe(5);
+
+      // Move bookmarkNode2 to distant folder
+      folderNode6.children.unshift(bookmarkNode2);
+      folderNode3.children = folderNode3.children.filter(
+        (node) => node.id !== bookmarkNode2.id
+      );
+
+      const moveInfo: browser.bookmarks._OnMovedMoveInfo = {
+        parentId: folderNode6.id,
+        index: 0,
+        oldParentId: folderNode3.id,
+        oldIndex: 0,
+      };
+
+      filterManager.handleBookmarkMoved(bookmarkNode2.id, moveInfo);
+
+      expect(filterSet.has(bookmarkNode1.id)).toBe(true);
+      expect(filterSet.has(bookmarkNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode3.id)).toBe(true);
+      expect(filterSet.has(folderNode5.id)).toBe(true);
+      expect(filterSet.has(folderNode6.id)).toBe(true);
+      expect(filterSet.size).toBe(7);
+    });
+
+    it('folder moved within folder', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode = folderNode2.children[0] as Treetop.BookmarkNode;
+      bookmarkNode.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.size).toBe(3);
+
+      // Move folderNode2 within folderNode1
+      expect(folderNode2.parentId!).toBe(folderNode1.id);
+      const oldIndex = folderNode1.children.findIndex(
+        (node) => node.id === folderNode2.id
+      );
+      expect(oldIndex).toBe(4);
+      const newIndex = folderNode1.children.length - 1;
+
+      const children = folderNode1.children;
+      [children[oldIndex], children[newIndex]] = [
+        children[newIndex],
+        children[oldIndex],
+      ];
+
+      const moveInfo: browser.bookmarks._OnMovedMoveInfo = {
+        parentId: folderNode1.id,
+        index: newIndex,
+        oldParentId: folderNode1.id,
+        oldIndex,
+      };
+
+      filterManager.handleBookmarkMoved(folderNode2.id, moveInfo);
+
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.size).toBe(3);
+    });
+
+    it('folder moved to a parent folder', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode = folderNode3.children[0] as Treetop.BookmarkNode;
+      bookmarkNode.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode3.id)).toBe(true);
+      expect(filterSet.size).toBe(4);
+
+      // Move folderNode3 to folderNode1
+      expect(folderNode3.parentId!).toBe(folderNode2.id);
+      const oldIndex = folderNode2.children.findIndex(
+        (node) => node.id === folderNode3.id
+      );
+      expect(oldIndex).toBe(3);
+      const newIndex = folderNode1.children.length - 1;
+
+      folderNode2.children = folderNode2.children.filter(
+        (node) => node.id !== folderNode3.id
+      );
+      folderNode3.parentId = folderNode1.id;
+      folderNode1.children.push(folderNode3);
+
+      const moveInfo: browser.bookmarks._OnMovedMoveInfo = {
+        parentId: folderNode1.id,
+        index: newIndex,
+        oldParentId: folderNode2.id,
+        oldIndex: oldIndex,
+      };
+
+      filterManager.handleBookmarkMoved(folderNode3.id, moveInfo);
+
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode3.id)).toBe(true);
+      expect(filterSet.size).toBe(3);
+    });
+
+    it('folder moved to a distant folder', () => {
+      const filter = faker.random.words(NUM_RANDOM_WORDS);
+      const bookmarkNode = folderNode3.children[0] as Treetop.BookmarkNode;
+      bookmarkNode.title += filter;
+      filterManager.setFilter(filter);
+
+      const filterSet = get(fs);
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode2.id)).toBe(true);
+      expect(filterSet.has(folderNode3.id)).toBe(true);
+      expect(filterSet.size).toBe(4);
+
+      // Move folderNode3 to folderNode5
+      expect(folderNode3.parentId!).toBe(folderNode2.id);
+      const oldIndex = folderNode2.children.findIndex(
+        (node) => node.id === folderNode3.id
+      );
+      expect(oldIndex).toBe(3);
+      const newIndex = folderNode5.children.length - 1;
+
+      folderNode2.children = folderNode2.children.filter(
+        (node) => node.id !== folderNode3.id
+      );
+      folderNode3.parentId = folderNode5.id;
+      folderNode5.children.push(folderNode3);
+
+      const moveInfo: browser.bookmarks._OnMovedMoveInfo = {
+        parentId: folderNode5.id,
+        index: newIndex,
+        oldParentId: folderNode2.id,
+        oldIndex: oldIndex,
+      };
+
+      filterManager.handleBookmarkMoved(folderNode3.id, moveInfo);
+
+      expect(filterSet.has(bookmarkNode.id)).toBe(true);
+      expect(filterSet.has(folderNode1.id)).toBe(true);
+      expect(filterSet.has(folderNode3.id)).toBe(true);
+      expect(filterSet.has(folderNode5.id)).toBe(true);
+      expect(filterSet.size).toBe(4);
+    });
+  });
+
+  describe('when filter is not set', () => {
+    it('ignores bookmarks', () => {
+      const bookmarkNode = folderNode2.children[1] as Treetop.BookmarkNode;
+
+      // Move bookmarkNode to index 0
+      const children = folderNode2.children;
+      [children[0], children[1]] = [children[1], children[0]];
+
+      const moveInfo: browser.bookmarks._OnMovedMoveInfo = {
+        parentId: bookmarkNode.parentId!,
+        index: 0,
+        oldParentId: bookmarkNode.parentId!,
+        oldIndex: 1,
+      };
+
+      filterManager.handleBookmarkMoved(bookmarkNode.id, moveInfo);
+
+      const filterSet = get(fs);
+      expect(filterSet.size).toBe(0);
+    });
+
+    it('ignores folders', () => {
+      // Move folderNode2 within folderNode1
+      expect(folderNode2.parentId!).toBe(folderNode1.id);
+      const oldIndex = folderNode1.children.findIndex(
+        (node) => node.id === folderNode2.id
+      );
+      expect(oldIndex).toBe(4);
+      const newIndex = folderNode1.children.length - 1;
+
+      const children = folderNode1.children;
+      [children[oldIndex], children[newIndex]] = [
+        children[newIndex],
+        children[oldIndex],
+      ];
+
+      const moveInfo: browser.bookmarks._OnMovedMoveInfo = {
+        parentId: folderNode1.id,
+        index: newIndex,
+        oldParentId: folderNode1.id,
+        oldIndex,
+      };
+
+      filterManager.handleBookmarkMoved(folderNode2.id, moveInfo);
+
+      const filterSet = get(fs);
+      expect(filterSet.size).toBe(0);
+    });
+  });
+});

--- a/test/treetop/Treetop.svelte.test.ts
+++ b/test/treetop/Treetop.svelte.test.ts
@@ -31,6 +31,7 @@ describe('Treetop', () => {
     mockBrowser.i18n.getMessage.expect('dialogButtonDelete');
 
     // Page header
+    mockBrowser.i18n.getMessage.expect('search');
     mockBrowser.i18n.getMessage.expect('preferences');
 
     // Properties dialog


### PR DESCRIPTION
Add a "Search" input that filters the visible bookmarks to those that match the search term. The search matches both bookmark names and URLs and is not case sensitive.