### PR TITLE
Update TypeScript syntax

### DIFF
--- a/src/background_script/menus.ts
+++ b/src/background_script/menus.ts
@@ -1,5 +1,4 @@
-import type { Menus } from 'webextension-polyfill';
-import browser from 'webextension-polyfill';
+import browser, { type Menus } from 'webextension-polyfill';
 
 /**
  * Create context menus.

--- a/src/background_script/open.ts
+++ b/src/background_script/open.ts
@@ -1,5 +1,8 @@
-import type { Action, Runtime, Tabs } from 'webextension-polyfill';
-import browser from 'webextension-polyfill';
+import browser, {
+  type Action,
+  type Runtime,
+  type Tabs,
+} from 'webextension-polyfill';
 
 /**
  * Open the welcome page when the extension is installed.

--- a/src/options/Options.svelte
+++ b/src/options/Options.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import type { Awaited } from 'treetop/types';
   import * as browser from 'webextension-polyfill';
 
   let options: Awaited<ReturnType<typeof browser.storage.local.get>>;

--- a/src/treetop/BookmarksManager.ts
+++ b/src/treetop/BookmarksManager.ts
@@ -1,6 +1,5 @@
 import { get, writable } from 'svelte/store';
-import type { Bookmarks } from 'webextension-polyfill';
-import browser from 'webextension-polyfill';
+import browser, { type Bookmarks } from 'webextension-polyfill';
 
 import {
   BOOKMARK_TREE_NODE_TYPE_BOOKMARK,

--- a/src/treetop/FilterInput.svelte
+++ b/src/treetop/FilterInput.svelte
@@ -5,8 +5,7 @@
   import TextField from '@smui/textfield';
   // FIXME: IconButton must appear after TextField, otherwise custom
   // TextField styles aren't applied correctly
-  import IconButton from '@smui/icon-button';
-  import type { IconButtonComponentDev } from '@smui/icon-button';
+  import IconButton, { type IconButtonComponentDev } from '@smui/icon-button';
   import debounce from 'lodash-es/debounce';
   import * as browser from 'webextension-polyfill';
 

--- a/src/treetop/Folder.svelte
+++ b/src/treetop/Folder.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { getContext } from 'svelte';
-  import type { Writable } from 'svelte/store';
-  import { get } from 'svelte/store';
+  import { type Writable, get } from 'svelte/store';
   import * as browser from 'webextension-polyfill';
 
   import Bookmark from './Bookmark.svelte';

--- a/src/treetop/HistoryManager.ts
+++ b/src/treetop/HistoryManager.ts
@@ -1,6 +1,5 @@
 import { get, writable } from 'svelte/store';
-import type { Bookmarks, History } from 'webextension-polyfill';
-import browser from 'webextension-polyfill';
+import browser, { type Bookmarks, type History } from 'webextension-polyfill';
 
 import { BOOKMARK_TREE_NODE_TYPE_BOOKMARK } from './constants';
 import * as Treetop from './types';

--- a/src/treetop/PreferencesManager.ts
+++ b/src/treetop/PreferencesManager.ts
@@ -1,7 +1,5 @@
-import type { Writable } from 'svelte/store';
-import { writable } from 'svelte/store';
-import type { Storage } from 'webextension-polyfill';
-import browser from 'webextension-polyfill';
+import { type Writable, writable } from 'svelte/store';
+import browser, { type Storage } from 'webextension-polyfill';
 
 import type * as Treetop from './types';
 

--- a/src/treetop/PropertiesDialog.svelte
+++ b/src/treetop/PropertiesDialog.svelte
@@ -3,8 +3,7 @@
   import type { MDCDialogCloseEvent } from '@material/dialog';
   import Button, { Label } from '@smui/button';
   import Dialog, { Actions, Content, Title } from '@smui/dialog';
-  import type { TextfieldComponentDev } from '@smui/textfield';
-  import TextField from '@smui/textfield';
+  import TextField, { type TextfieldComponentDev } from '@smui/textfield';
   import truncate from 'lodash-es/truncate';
   import * as browser from 'webextension-polyfill';
 

--- a/src/treetop/Treetop.svelte
+++ b/src/treetop/Treetop.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
   import { onDestroy, onMount, setContext } from 'svelte';
-  import type { Unsubscriber, Writable } from 'svelte/store';
-  import { get, writable } from 'svelte/store';
+  import {
+    type Unsubscriber,
+    type Writable,
+    get,
+    writable,
+  } from 'svelte/store';
   import { fade } from 'svelte/transition';
   import LinearProgress from '@smui/linear-progress';
-  import type { SnackbarComponentDev } from '@smui/snackbar';
-  import Snackbar, { Label } from '@smui/snackbar';
+  import Snackbar, { type SnackbarComponentDev, Label } from '@smui/snackbar';
   import type { Bookmarks, History, Menus, Tabs } from 'webextension-polyfill';
   import * as browser from 'webextension-polyfill';
 

--- a/src/treetop/menus/DeleteMenuItem.ts
+++ b/src/treetop/menus/DeleteMenuItem.ts
@@ -1,5 +1,4 @@
-import type { Writable } from 'svelte/store';
-import { get } from 'svelte/store';
+import { type Writable, get } from 'svelte/store';
 
 import {
   BOOKMARKS_MENU_GUID,
@@ -9,8 +8,7 @@ import {
 } from '@Treetop/treetop/constants';
 import type * as Treetop from '@Treetop/treetop/types';
 
-import type { OnClickedCallback } from './MenuItem';
-import { MenuItem } from './MenuItem';
+import { type OnClickedCallback, MenuItem } from './MenuItem';
 
 /**
  * Menu item to delete a bookmark or folder.

--- a/src/treetop/menus/MenuManager.ts
+++ b/src/treetop/menus/MenuManager.ts
@@ -1,5 +1,4 @@
-import type { Menus, Tabs } from 'webextension-polyfill';
-import browser from 'webextension-polyfill';
+import browser, { type Menus, type Tabs } from 'webextension-polyfill';
 
 import type { MenuItem } from './MenuItem';
 

--- a/src/treetop/menus/OpenAllInTabsMenuItem.ts
+++ b/src/treetop/menus/OpenAllInTabsMenuItem.ts
@@ -3,8 +3,7 @@ import { get } from 'svelte/store';
 import { BOOKMARKS_ROOT_GUID } from '@Treetop/treetop/constants';
 import type * as Treetop from '@Treetop/treetop/types';
 
-import type { OnClickedCallback } from './MenuItem';
-import { MenuItem } from './MenuItem';
+import { type OnClickedCallback, MenuItem } from './MenuItem';
 
 /**
  * Menu item to open a folder's immediate children in tabs.

--- a/src/treetop/menus/PropertiesMenuItem.ts
+++ b/src/treetop/menus/PropertiesMenuItem.ts
@@ -5,8 +5,7 @@ import {
   OTHER_BOOKMARKS_GUID,
 } from '@Treetop/treetop/constants';
 
-import type { OnClickedCallback } from './MenuItem';
-import { MenuItem } from './MenuItem';
+import { type OnClickedCallback, MenuItem } from './MenuItem';
 
 /**
  * Menu item to show the properties dialog for a bookmark or folder.

--- a/src/treetop/types.ts
+++ b/src/treetop/types.ts
@@ -55,12 +55,3 @@ export type PreferenceValue =
   | string[]
   | number[]
   | boolean[];
-
-// Type to unwrap Promises. See:
-// - https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#recursive-conditional-types
-// - https://github.com/microsoft/TypeScript/pull/40002
-export type Awaited<T> = T extends null | undefined
-  ? T
-  : T extends PromiseLike<infer U>
-  ? Awaited<U>
-  : T;

--- a/test/treetop/Bookmark.svelte.test.ts
+++ b/test/treetop/Bookmark.svelte.test.ts
@@ -1,5 +1,4 @@
-import type { Writable } from 'svelte/store';
-import { writable } from 'svelte/store';
+import { type Writable, writable } from 'svelte/store';
 import { render, screen } from '@testing-library/svelte';
 import faker from 'faker';
 import escapeRegExp from 'lodash-es/escapeRegExp';

--- a/test/treetop/BookmarksManager.test.ts
+++ b/test/treetop/BookmarksManager.test.ts
@@ -1,7 +1,6 @@
 /* eslint no-irregular-whitespace: ["error", { "skipComments": true }] */
 
-import type { Writable } from 'svelte/store';
-import { get } from 'svelte/store';
+import { type Writable, get } from 'svelte/store';
 import faker from 'faker';
 import type { Bookmarks } from 'webextension-polyfill';
 

--- a/test/treetop/Folder.svelte.test.ts
+++ b/test/treetop/Folder.svelte.test.ts
@@ -1,7 +1,6 @@
 /* eslint no-irregular-whitespace: ["error", { "skipComments": true }] */
 
-import type { Writable } from 'svelte/store';
-import { get, writable } from 'svelte/store';
+import { type Writable, get, writable } from 'svelte/store';
 import { render, screen } from '@testing-library/svelte';
 
 import { BOOKMARKS_ROOT_GUID } from '@Treetop/treetop/constants';

--- a/test/treetop/PreferencesManager.test.ts
+++ b/test/treetop/PreferencesManager.test.ts
@@ -1,5 +1,4 @@
-import type { Writable } from 'svelte/store';
-import { get } from 'svelte/store';
+import { type Writable, get } from 'svelte/store';
 import faker from 'faker';
 
 import { PreferencesManager } from '@Treetop/treetop/PreferencesManager';

--- a/test/treetop/menus/DeleteMenuItem.test.ts
+++ b/test/treetop/menus/DeleteMenuItem.test.ts
@@ -1,5 +1,4 @@
-import type { Writable } from 'svelte/store';
-import { writable } from 'svelte/store';
+import { type Writable, writable } from 'svelte/store';
 import faker from 'faker';
 
 import {


### PR DESCRIPTION
Update source code to take advantage of features introduced in TypeScript 4.5:
- [Type-only import specifiers](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#type-on-import-names)
- [Built-in `Awaited` type](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#awaited-type)