### PR TITLE
Fix loading stored options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Changed
 - Update Svelte Material UI to 6.0.0-beta.16.
+
+### Removed
 - Remove option to follow the system color scheme.
+
+### Fixed
+- Fix loading stored options.
 
 ## [1.3.0] - 2021-10-02
 ### Added

--- a/src/background_script/init.ts
+++ b/src/background_script/init.ts
@@ -15,7 +15,17 @@ export const init = async (): Promise<void> => {
   browser.browserAction.onClicked.addListener(openTreetop);
 
   // Set default options
-  await setDefaultOptions();
+  const options = {
+    showBookmarksToolbar: true,
+    showBookmarksMenu: true,
+    showOtherBookmarks: true,
+    truncate: true,
+    tooltips: true,
+    showRecentlyVisited: true,
+    colorScheme: 'light',
+  };
+
+  await setDefaultOptions(options);
 
   // Create context menus
   createContextMenus();

--- a/src/background_script/options.ts
+++ b/src/background_script/options.ts
@@ -1,22 +1,27 @@
 import browser from 'webextension-polyfill';
 
-/**
- * Set default options.
- */
-export const setDefaultOptions = async (): Promise<void> => {
-  const defaultOptions = {
-    showBookmarksToolbar: true,
-    showBookmarksMenu: true,
-    showOtherBookmarks: true,
-    truncate: true,
-    tooltips: true,
-    showRecentlyVisited: true,
-    colorScheme: 'light',
-  };
+import type * as Treetop from '@Treetop/treetop/types';
 
+/**
+ * Set default options, leaving existing options unchanged.
+ */
+export const setDefaultOptions = async (
+  defaultOptions: Record<string, Treetop.PreferenceValue>
+): Promise<void> => {
   try {
-    await browser.storage.local.set(defaultOptions);
+    // Get stored options
+    const storedOptions = await browser.storage.local.get();
+
+    // Merge stored options into default options
+    const updatedOptions = {
+      ...defaultOptions,
+      ...storedOptions,
+    };
+
+    // Update stored options
+    await browser.storage.local.set(updatedOptions);
   } catch (err) {
     console.error('Error setting default options:', err);
+    throw err;
   }
 };

--- a/test/background_script/options.test.ts
+++ b/test/background_script/options.test.ts
@@ -1,7 +1,79 @@
 import { setDefaultOptions } from '@Treetop/background_script/options';
+import type * as Treetop from '@Treetop/treetop/types';
 
-it('sets default options', async () => {
-  mockBrowser.storage.local.set.expect;
+let defaultOptions: Record<string, Treetop.PreferenceValue>;
 
-  await setDefaultOptions();
+beforeEach(() => {
+  defaultOptions = {
+    a: true,
+    b: false,
+    c: 0,
+    d: 1,
+    e: 'test1',
+    f: 'test2',
+    g: [false, true],
+    h: [1, 2],
+    i: ['test1', 'test2'],
+  };
+});
+
+it('sets default options when no options are stored', async () => {
+  const storedOptions = {};
+  const updatedOptions = {
+    ...defaultOptions,
+  };
+
+  mockBrowser.storage.local.get.expect.andResolve(storedOptions);
+  mockBrowser.storage.local.set.expect(updatedOptions);
+
+  await setDefaultOptions(defaultOptions);
+});
+
+it('leaves existing options unchanged', async () => {
+  const storedOptions = {
+    a: false,
+    b: true,
+    c: 2,
+    d: 3,
+    e: 'test3',
+    f: 'test4',
+    g: [true, false, false],
+    h: [3, 0, 1],
+    i: ['test3', 'test4'],
+  };
+
+  const updatedOptions = {
+    ...storedOptions,
+  };
+
+  mockBrowser.storage.local.get.expect.andResolve(storedOptions);
+  mockBrowser.storage.local.set.expect(updatedOptions);
+
+  await setDefaultOptions(defaultOptions);
+});
+
+it('sets default options and leaves existing options unchanged', async () => {
+  const storedOptions = {
+    a: false,
+    c: 3,
+    e: 'test2',
+    h: [3, 0],
+  };
+
+  const updatedOptions = {
+    a: false,
+    b: false,
+    c: 3,
+    d: 1,
+    e: 'test2',
+    f: 'test2',
+    g: [false, true],
+    h: [3, 0],
+    i: ['test1', 'test2'],
+  };
+
+  mockBrowser.storage.local.get.expect.andResolve(storedOptions);
+  mockBrowser.storage.local.set.expect(updatedOptions);
+
+  await setDefaultOptions(defaultOptions);
 });


### PR DESCRIPTION
Fix a bug where the stored options were always overwritten with the default options.