### PR TITLE
Prefer contextMenus API over menus API

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -46,4 +46,5 @@ module.exports = {
     '!**/node_modules/**',
   ],
   coverageProvider: 'v8',
+  clearMocks: true,
 };

--- a/src/background_script/init.ts
+++ b/src/background_script/init.ts
@@ -9,6 +9,9 @@ import { setDefaultOptions } from './options';
  * Initialize Treetop.
  */
 export const init = async (): Promise<void> => {
+  // Install handler to create context menus when the extension is installed
+  browser.runtime.onInstalled.addListener(createContextMenus);
+
   // Install handler to open the welcome page when the extension is installed
   browser.runtime.onInstalled.addListener(openWelcome);
 
@@ -27,7 +30,4 @@ export const init = async (): Promise<void> => {
   };
 
   await setDefaultOptions(options);
-
-  // Create context menus
-  createContextMenus();
 };

--- a/src/background_script/menus.ts
+++ b/src/background_script/menus.ts
@@ -16,31 +16,31 @@ export const createContextMenus = (): void => {
     documentUrlPatterns: [`${origin}*`],
   };
 
-  browser.menus.create({
+  browser.contextMenus.create({
     id: 'openAllInTabs',
     title: browser.i18n.getMessage('menuItemOpenAllInTabs'),
     ...commonMenuParams,
   });
 
-  browser.menus.create({
+  browser.contextMenus.create({
     id: 'separator1',
     type: 'separator',
     ...commonMenuParams,
   });
 
-  browser.menus.create({
+  browser.contextMenus.create({
     id: 'delete',
     title: browser.i18n.getMessage('menuItemDelete'),
     ...commonMenuParams,
   });
 
-  browser.menus.create({
+  browser.contextMenus.create({
     id: 'separator2',
     type: 'separator',
     ...commonMenuParams,
   });
 
-  browser.menus.create({
+  browser.contextMenus.create({
     id: 'properties',
     title: browser.i18n.getMessage('menuItemProperties'),
     ...commonMenuParams,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -32,7 +32,7 @@
     "page": "options.html",
     "browser_style": true
   },
-  "permissions": ["bookmarks", "history", "menus", "storage"],
+  "permissions": ["bookmarks", "contextMenus", "history", "storage"],
   "browser_specific_settings": {
     "gecko": {
       "id": "treetop@maxsmolens.org",

--- a/src/treetop/Treetop.svelte
+++ b/src/treetop/Treetop.svelte
@@ -428,6 +428,13 @@
   // Menu event handlers
   //
 
+  function onContextMenu(event: Event) {
+    // Record the target element of the context menu
+    if (menuManager && event.target instanceof HTMLElement) {
+      menuManager.activeElement = event.target;
+    }
+  }
+
   async function asyncOnMenuShown(info: Menus.OnShownInfoType, tab: Tabs.Tab) {
     await menuManager?.handleMenuShown(info, tab);
   }
@@ -545,9 +552,10 @@
     body = document.body;
 
     // Register menu event handlers
-    browser.menus.onShown.addListener(onMenuShown);
-    browser.menus.onHidden.addListener(onMenuHidden);
-    browser.menus.onClicked.addListener(onMenuClicked);
+    document.addEventListener('contextmenu', onContextMenu);
+    browser.contextMenus.onShown.addListener(onMenuShown);
+    browser.contextMenus.onHidden.addListener(onMenuHidden);
+    browser.contextMenus.onClicked.addListener(onMenuClicked);
 
     // Initialize menu manager
     menuManager = new MenuManager();
@@ -572,9 +580,10 @@
     unsubscribeShowRecentlyVisited();
 
     // Unregister menu event handlers
-    browser.menus.onShown.removeListener(onMenuShown);
-    browser.menus.onHidden.removeListener(onMenuHidden);
-    browser.menus.onClicked.removeListener(onMenuClicked);
+    document.removeEventListener('contextmenu', onContextMenu);
+    browser.contextMenus.onShown.removeListener(onMenuShown);
+    browser.contextMenus.onHidden.removeListener(onMenuHidden);
+    browser.contextMenus.onClicked.removeListener(onMenuClicked);
 
     // Destroy menu manager
     menuManager = null;

--- a/test/background_script/init.test.ts
+++ b/test/background_script/init.test.ts
@@ -13,12 +13,26 @@ jest
   .mock('@Treetop/background_script/options');
 
 it('initializes extension', async () => {
+  mockBrowser.runtime.onInstalled.addListener.expect(createContextMenus);
   mockBrowser.runtime.onInstalled.addListener.expect(openWelcome);
   mockBrowser.browserAction.onClicked.addListener.expect(openTreetop);
 
   await init();
 
   expect(setDefaultOptions).toHaveBeenCalledTimes(1);
+});
+
+it('creates context menus when the extension is installed', async () => {
+  const runtimeOnInstalled = mockEvent(mockBrowser.runtime.onInstalled);
+  mockBrowser.browserAction.onClicked.addListener.expect(openTreetop);
+
+  await init();
+
+  runtimeOnInstalled.emit({
+    reason: 'install',
+    temporary: false,
+  });
+
   expect(createContextMenus).toHaveBeenCalledTimes(1);
 });
 
@@ -38,6 +52,7 @@ it('opens the welcome page when the extension is installed', async () => {
 
 it('opens Treetop when the browser action is clicked', async () => {
   const browserActionClicked = mockEvent(mockBrowser.browserAction.onClicked);
+  mockBrowser.runtime.onInstalled.addListener.expect(createContextMenus);
   mockBrowser.runtime.onInstalled.addListener.expect(openWelcome);
 
   await init();

--- a/test/background_script/menus.test.ts
+++ b/test/background_script/menus.test.ts
@@ -6,7 +6,7 @@ const NUM_SEPARATORS = 2;
 it('creates context menus', () => {
   mockBrowser.runtime.getURL.expect('');
   mockBrowser.i18n.getMessage.expect.times(NUM_ACTIONS);
-  mockBrowser.menus.create.expect.times(NUM_ACTIONS + NUM_SEPARATORS);
+  mockBrowser.contextMenus.create.expect.times(NUM_ACTIONS + NUM_SEPARATORS);
 
   createContextMenus();
 });

--- a/test/treetop/Treetop.svelte.test.ts
+++ b/test/treetop/Treetop.svelte.test.ts
@@ -44,9 +44,9 @@ describe('Treetop', () => {
     //
 
     // Menu event handlers
-    mockBrowser.menus.onShown.addListener.expect(expect.any(Function));
-    mockBrowser.menus.onHidden.addListener.expect(expect.any(Function));
-    mockBrowser.menus.onClicked.addListener.expect(expect.any(Function));
+    mockBrowser.contextMenus.onShown.addListener.expect(expect.any(Function));
+    mockBrowser.contextMenus.onHidden.addListener.expect(expect.any(Function));
+    mockBrowser.contextMenus.onClicked.addListener.expect(expect.any(Function));
 
     //
     // init()
@@ -88,9 +88,15 @@ describe('Treetop', () => {
     // onDestroy
     //
 
-    mockBrowser.menus.onShown.removeListener.expect(expect.any(Function));
-    mockBrowser.menus.onHidden.removeListener.expect(expect.any(Function));
-    mockBrowser.menus.onClicked.removeListener.expect(expect.any(Function));
+    mockBrowser.contextMenus.onShown.removeListener.expect(
+      expect.any(Function)
+    );
+    mockBrowser.contextMenus.onHidden.removeListener.expect(
+      expect.any(Function)
+    );
+    mockBrowser.contextMenus.onClicked.removeListener.expect(
+      expect.any(Function)
+    );
 
     cleanup();
   });

--- a/test/treetop/menus/MenuManager.test.ts
+++ b/test/treetop/menus/MenuManager.test.ts
@@ -87,16 +87,14 @@ describe('handleMenuShown', () => {
   });
 
   it('updates whether menu items are enabled', async () => {
-    const element = createElement();
     mockBrowser.runtime.getURL.expect('').andReturn(origin);
     mockBrowser.tabs.getCurrent.expect.andResolve(tab);
-    mockBrowser.menus.getTargetElement
-      .expect(info.targetElementId!)
-      // @ts-ignore
-      .andReturn(element);
-    mockBrowser.menus.update.expect('test1', { enabled: true });
-    mockBrowser.menus.update.expect('test2', { enabled: false });
-    mockBrowser.menus.refresh.expect;
+    mockBrowser.contextMenus.update.expect('test1', { enabled: true });
+    mockBrowser.contextMenus.update.expect('test2', { enabled: false });
+    mockBrowser.contextMenus.refresh.expect;
+
+    // @ts-ignore
+    menuManager.activeElement = createElement();
 
     await menuManager.handleMenuShown(info, tab);
   });
@@ -104,11 +102,17 @@ describe('handleMenuShown', () => {
   it("no-op if context is not 'link'", async () => {
     info.contexts = ['page'];
 
+    // @ts-ignore
+    menuManager.activeElement = createElement();
+
     await menuManager.handleMenuShown(info, tab);
   });
 
   it("no-op if viewType is not 'tab'", async () => {
     info.viewType = 'popup';
+
+    // @ts-ignore
+    menuManager.activeElement = createElement();
 
     await menuManager.handleMenuShown(info, tab);
   });
@@ -118,6 +122,9 @@ describe('handleMenuShown', () => {
 
     mockBrowser.runtime.getURL.expect('').andReturn(origin);
 
+    // @ts-ignore
+    menuManager.activeElement = createElement();
+
     await menuManager.handleMenuShown(info, tab);
   });
 
@@ -125,6 +132,9 @@ describe('handleMenuShown', () => {
     info.pageUrl = faker.internet.url();
 
     mockBrowser.runtime.getURL.expect('').andReturn(origin);
+
+    // @ts-ignore
+    menuManager.activeElement = createElement();
 
     await menuManager.handleMenuShown(info, tab);
   });
@@ -135,11 +145,14 @@ describe('handleMenuShown', () => {
     const otherTab = createTab();
     mockBrowser.tabs.getCurrent.expect.andResolve(otherTab);
 
+    // @ts-ignore
+    menuManager.activeElement = createElement();
+
     await menuManager.handleMenuShown(info, tab);
   });
 
-  it("no-op if targetElementId isn't provided", async () => {
-    delete info.targetElementId;
+  it("no-op if active element isn't provided", async () => {
+    menuManager.activeElement = null;
 
     mockBrowser.runtime.getURL.expect('').andReturn(origin);
     mockBrowser.tabs.getCurrent.expect.andResolve(tab);
@@ -148,14 +161,11 @@ describe('handleMenuShown', () => {
   });
 
   it("no-op if nodeId isn't available", async () => {
-    const element = createElement(false);
+    // @ts-ignore
+    menuManager.activeElement = createElement(false);
 
     mockBrowser.runtime.getURL.expect('').andReturn(origin);
     mockBrowser.tabs.getCurrent.expect.andResolve(tab);
-    mockBrowser.menus.getTargetElement
-      .expect(info.targetElementId!)
-      // @ts-ignore
-      .andReturn(element);
 
     await menuManager.handleMenuShown(info, tab);
   });
@@ -199,10 +209,9 @@ describe('handleMenuClicked', () => {
   it('calls a registered menu item handler', async () => {
     const element = createElement();
     mockBrowser.tabs.getCurrent.expect.andResolve(tab);
-    mockBrowser.menus.getTargetElement
-      .expect(info.targetElementId!)
-      // @ts-ignore
-      .andReturn(element);
+
+    // @ts-ignore
+    menuManager.activeElement = element;
 
     await menuManager.handleMenuClicked(info, tab);
 
@@ -214,6 +223,9 @@ describe('handleMenuClicked', () => {
   it("no-op if viewType is not 'tab'", async () => {
     info.viewType = 'popup';
 
+    // @ts-ignore
+    menuManager.activeElement = createElement();
+
     await menuManager.handleMenuClicked(info, tab);
 
     expect(test1Clicked).toBe(false);
@@ -223,6 +235,9 @@ describe('handleMenuClicked', () => {
   it('no-op if tab is not provided', async () => {
     await menuManager.handleMenuClicked(info);
 
+    // @ts-ignore
+    menuManager.activeElement = createElement();
+
     expect(test1Clicked).toBe(false);
     expect(test2Clicked).toBe(false);
   });
@@ -231,14 +246,17 @@ describe('handleMenuClicked', () => {
     const otherTab = createTab();
     mockBrowser.tabs.getCurrent.expect.andResolve(otherTab);
 
+    // @ts-ignore
+    menuManager.activeElement = createElement();
+
     await menuManager.handleMenuClicked(info, tab);
 
     expect(test1Clicked).toBe(false);
     expect(test2Clicked).toBe(false);
   });
 
-  it("no-op if targetElementId isn't provided", async () => {
-    delete info.targetElementId;
+  it("no-op if active element isn't provided", async () => {
+    menuManager.activeElement = null;
 
     mockBrowser.tabs.getCurrent.expect.andResolve(tab);
 
@@ -249,13 +267,10 @@ describe('handleMenuClicked', () => {
   });
 
   it("no-op if nodeId isn't available", async () => {
-    const element = createElement(false);
+    // @ts-ignore
+    menuManager.activeElement = createElement(false);
 
     mockBrowser.tabs.getCurrent.expect.andResolve(tab);
-    mockBrowser.menus.getTargetElement
-      .expect(info.targetElementId!)
-      // @ts-ignore
-      .andReturn(element);
 
     await menuManager.handleMenuClicked(info, tab);
 
@@ -264,14 +279,12 @@ describe('handleMenuClicked', () => {
   });
 
   it("no-op if menuItemId isn't registered", async () => {
-    const element = createElement();
     info.menuItemId = 'other';
 
     mockBrowser.tabs.getCurrent.expect.andResolve(tab);
-    mockBrowser.menus.getTargetElement
-      .expect(info.targetElementId!)
-      // @ts-ignore
-      .andReturn(element);
+
+    // @ts-ignore
+    menuManager.activeElement = createElement();
 
     await menuManager.handleMenuClicked(info, tab);
 


### PR DESCRIPTION
Replace usage of the menus API with the contextMenus API. This is a step towards compatibility with Chrome.

Note that the contextMenus API lacks some features of the menus API. Specifically, the click data doesn't include a `targetElementId` property, like in [menus.OnClickData](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/OnClickData). Therefore, we now manually track the target element of the context menu.