### PR TITLE
Remove options to set visibility of built-in bookmark folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Removed
+- Remove options to set visibility of built-in bookmark folders.
 
 ## [1.5.0] - 2022-09-27
 ### Changed

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -72,18 +72,6 @@
     "message": "Appearance",
     "description": "Title of group for appearance options."
   },
-  "optionShowBookmarksToolbar": {
-    "message": "Show Bookmarks Toolbar",
-    "description": "Title of option to show the Bookmarks Toolbar folder."
-  },
-  "optionShowBookmarksMenu": {
-    "message": "Show Bookmarks Menu",
-    "description": "Title of option to show the Bookmarks Menu folder."
-  },
-  "optionShowOtherBookmarks": {
-    "message": "Show Other Bookmarks",
-    "description": "Title of option to show the Other Bookmarks folder."
-  },
   "optionTruncateLongTitles": {
     "message": "Truncate long titles",
     "description": "Title of option to truncate long bookmark titles."

--- a/src/options/Options.svelte
+++ b/src/options/Options.svelte
@@ -5,12 +5,8 @@
   let options: Awaited<ReturnType<typeof browser.storage.local.get>>;
 
   const strings = {
-    general: browser.i18n.getMessage('optionHeadingGeneral'),
     bookmarks: browser.i18n.getMessage('optionHeadingBookmarks'),
     appearance: browser.i18n.getMessage('optionHeadingAppearance'),
-    showBookmarksToolbar: browser.i18n.getMessage('optionShowBookmarksToolbar'),
-    showBookmarksMenu: browser.i18n.getMessage('optionShowBookmarksMenu'),
-    showOtherBookmarks: browser.i18n.getMessage('optionShowOtherBookmarks'),
     truncate: browser.i18n.getMessage('optionTruncateLongTitles'),
     tooltips: browser.i18n.getMessage('optionDisplayTooltips'),
     showRecentlyVisited: browser.i18n.getMessage('optionShowRecentlyVisited'),
@@ -103,38 +99,6 @@
 </style>
 
 {#if options}
-  <h3>{strings.general}</h3>
-  <div>
-    <label>
-      <input
-        type="checkbox"
-        bind:checked={options.showBookmarksToolbar}
-        on:change={handleCheckboxChange}
-        data-option-name="showBookmarksToolbar" />
-      {strings.showBookmarksToolbar}
-    </label>
-  </div>
-  <div>
-    <label>
-      <input
-        type="checkbox"
-        bind:checked={options.showBookmarksMenu}
-        on:change={handleCheckboxChange}
-        data-option-name="showBookmarksMenu" />
-      {strings.showBookmarksMenu}
-    </label>
-  </div>
-  <div>
-    <label>
-      <input
-        type="checkbox"
-        bind:checked={options.showOtherBookmarks}
-        on:change={handleCheckboxChange}
-        data-option-name="showOtherBookmarks" />
-      {strings.showOtherBookmarks}
-    </label>
-  </div>
-
   <h3>{strings.bookmarks}</h3>
   <div>
     <label>

--- a/src/treetop/BookmarksManager.ts
+++ b/src/treetop/BookmarksManager.ts
@@ -23,10 +23,6 @@ const BookmarkTypeMap: Map<Bookmarks.BookmarkTreeNodeType, Treetop.NodeType> =
  * Class to initialize and manage updating bookmark node stores.
  */
 export class BookmarksManager {
-  showBookmarksToolbar = true;
-  showBookmarksMenu = true;
-  showOtherBookmarks = true;
-
   constructor(private readonly nodeStoreMap: Treetop.NodeStoreMap) {}
 
   /**
@@ -237,26 +233,20 @@ export class BookmarksManager {
   private orderBookmarksRootChildren(node: Bookmarks.BookmarkTreeNode): void {
     const children: Bookmarks.BookmarkTreeNode[] = [];
 
-    if (this.showBookmarksToolbar) {
-      const bookmarksToolbarNode = node.children!.find(
-        ({ id }) => id === BOOKMARKS_TOOLBAR_GUID
-      )!;
-      children.push(bookmarksToolbarNode);
-    }
+    const bookmarksToolbarNode = node.children!.find(
+      ({ id }) => id === BOOKMARKS_TOOLBAR_GUID
+    )!;
+    children.push(bookmarksToolbarNode);
 
-    if (this.showBookmarksMenu) {
-      const bookmarksMenuNode = node.children!.find(
-        ({ id }) => id === BOOKMARKS_MENU_GUID
-      )!;
-      children.push(bookmarksMenuNode);
-    }
+    const bookmarksMenuNode = node.children!.find(
+      ({ id }) => id === BOOKMARKS_MENU_GUID
+    )!;
+    children.push(bookmarksMenuNode);
 
-    if (this.showOtherBookmarks) {
-      const otherBookmarksNode = node.children!.find(
-        ({ id }) => id === OTHER_BOOKMARKS_GUID
-      )!;
-      children.push(otherBookmarksNode);
-    }
+    const otherBookmarksNode = node.children!.find(
+      ({ id }) => id === OTHER_BOOKMARKS_GUID
+    )!;
+    children.push(otherBookmarksNode);
 
     node.children = children;
   }

--- a/src/treetop/Treetop.svelte
+++ b/src/treetop/Treetop.svelte
@@ -38,18 +38,6 @@
   //
 
   const preferencesManager = new PreferencesManager();
-  const showBookmarksToolbar = preferencesManager.createStore(
-    'showBookmarksToolbar',
-    true
-  );
-  const showBookmarksMenu = preferencesManager.createStore(
-    'showBookmarksMenu',
-    true
-  );
-  const showOtherBookmarks = preferencesManager.createStore(
-    'showOtherBookmarks',
-    true
-  );
   const truncate = preferencesManager.createStore('truncate', true);
   const tooltips = preferencesManager.createStore('tooltips', true);
   const showRecentlyVisited = preferencesManager.createStore(
@@ -492,11 +480,6 @@
       console.error(err);
       handleError(browser.i18n.getMessage('errorLoadingPreferences'));
     }
-
-    // Configure bookmarks manager
-    bookmarksManager.showBookmarksToolbar = $showBookmarksToolbar as boolean;
-    bookmarksManager.showBookmarksMenu = $showBookmarksMenu as boolean;
-    bookmarksManager.showOtherBookmarks = $showOtherBookmarks as boolean;
 
     // Register bookmark event handlers
     browser.bookmarks.onCreated.addListener(onBookmarkCreated);

--- a/test/options/Options.svelte.test.ts
+++ b/test/options/Options.svelte.test.ts
@@ -15,23 +15,11 @@ const setup = () => {
 describe('Options', () => {
   beforeEach(() => {
     mockBrowser.i18n.getMessage
-      .expect('optionHeadingGeneral')
-      .andReturn('general');
-    mockBrowser.i18n.getMessage
       .expect('optionHeadingBookmarks')
       .andReturn('bookmarks');
     mockBrowser.i18n.getMessage
       .expect('optionHeadingAppearance')
       .andReturn('appearance');
-    mockBrowser.i18n.getMessage
-      .expect('optionShowBookmarksToolbar')
-      .andReturn('show bookmarks toolbar');
-    mockBrowser.i18n.getMessage
-      .expect('optionShowBookmarksMenu')
-      .andReturn('show bookmarks menu');
-    mockBrowser.i18n.getMessage
-      .expect('optionShowOtherBookmarks')
-      .andReturn('show other bookmarks');
     mockBrowser.i18n.getMessage
       .expect('optionTruncateLongTitles')
       .andReturn('truncate');
@@ -55,9 +43,6 @@ describe('Options', () => {
       .andReturn('attributions');
 
     mockBrowser.storage.local.get.expect.andResolve({
-      showBookmarksToolbar: true,
-      showBookmarksMenu: false,
-      showOtherBookmarks: true,
       truncate: false,
       tooltips: true,
       showRecentlyVisited: true,
@@ -69,18 +54,8 @@ describe('Options', () => {
     setup();
 
     await waitFor(() => {
-      expect(screen.getByText(/^general/i)).toBeInTheDocument();
       expect(screen.getByText(/^bookmarks/i)).toBeInTheDocument();
       expect(screen.getByText(/^appearance/i)).toBeInTheDocument();
-      expect(
-        screen.getByLabelText(/^show bookmarks toolbar/i)
-      ).toBeInTheDocument();
-      expect(
-        screen.getByLabelText(/^show bookmarks menu/i)
-      ).toBeInTheDocument();
-      expect(
-        screen.getByLabelText(/^show other bookmarks/i)
-      ).toBeInTheDocument();
       expect(screen.getByLabelText(/^truncate/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/^tooltips/i)).toBeInTheDocument();
       expect(
@@ -101,12 +76,9 @@ describe('Options', () => {
     setup();
 
     await waitFor(() => {
-      expect(screen.getByText(/^general/i)).toBeInTheDocument();
+      expect(screen.getByText(/^bookmarks/i)).toBeInTheDocument();
     });
 
-    expect(screen.getByLabelText(/^show bookmarks toolbar/i)).toBeChecked();
-    expect(screen.getByLabelText(/^show bookmarks menu/i)).not.toBeChecked();
-    expect(screen.getByLabelText(/^show other bookmarks/i)).toBeChecked();
     expect(screen.getByLabelText(/^truncate/i)).not.toBeChecked();
     expect(screen.getByLabelText(/^tooltips/i)).toBeChecked();
     expect(screen.getByLabelText(/^show recently visited/i)).toBeChecked();

--- a/test/treetop/BookmarksManager.test.ts
+++ b/test/treetop/BookmarksManager.test.ts
@@ -225,10 +225,6 @@ describe('loadBookmarks', () => {
   it("reorders root boookmark node's children", async () => {
     mockBrowser.bookmarks.getTree.expect.andResolve(bookmarksTree);
 
-    expect(bookmarksManager.showBookmarksToolbar).toBe(true);
-    expect(bookmarksManager.showBookmarksMenu).toBe(true);
-    expect(bookmarksManager.showOtherBookmarks).toBe(true);
-
     await bookmarksManager.loadBookmarks();
 
     expect(nodeStoreMap.size).toBe(NUM_BOOKMARK_ROOTS);
@@ -254,90 +250,6 @@ describe('loadBookmarks', () => {
           title: 'Other Bookmarks',
         },
       ],
-    });
-  });
-
-  describe('respects options', () => {
-    beforeEach(() => {
-      mockBrowser.bookmarks.getTree.expect.andResolve(bookmarksTree);
-    });
-
-    it('showBookmarksToolbar', async () => {
-      bookmarksManager.showBookmarksToolbar = false;
-
-      await bookmarksManager.loadBookmarks();
-
-      expect(nodeStoreMap.size).toBe(NUM_BOOKMARK_ROOTS - 1);
-      expect(nodeStoreMap.get(BOOKMARKS_ROOT_GUID)).toBeDefined();
-      expect(get(nodeStoreMap.get(BOOKMARKS_ROOT_GUID)!)).toMatchObject({
-        id: BOOKMARKS_ROOT_GUID,
-        type: Treetop.NodeType.Folder,
-        title: '',
-        children: [
-          {
-            id: BOOKMARKS_MENU_GUID,
-            type: Treetop.NodeType.Folder,
-            title: 'Bookmarks Menu',
-          },
-          {
-            id: OTHER_BOOKMARKS_GUID,
-            type: Treetop.NodeType.Folder,
-            title: 'Other Bookmarks',
-          },
-        ],
-      });
-    });
-
-    it('showBookmarksMenu', async () => {
-      bookmarksManager.showBookmarksMenu = false;
-
-      await bookmarksManager.loadBookmarks();
-
-      expect(nodeStoreMap.size).toBe(NUM_BOOKMARK_ROOTS - 1);
-      expect(nodeStoreMap.get(BOOKMARKS_ROOT_GUID)).toBeDefined();
-      expect(get(nodeStoreMap.get(BOOKMARKS_ROOT_GUID)!)).toMatchObject({
-        id: BOOKMARKS_ROOT_GUID,
-        type: Treetop.NodeType.Folder,
-        title: '',
-        children: [
-          {
-            id: BOOKMARKS_TOOLBAR_GUID,
-            type: Treetop.NodeType.Folder,
-            title: 'Bookmarks Toolbar',
-          },
-          {
-            id: OTHER_BOOKMARKS_GUID,
-            type: Treetop.NodeType.Folder,
-            title: 'Other Bookmarks',
-          },
-        ],
-      });
-    });
-
-    it('showOtherBookmarks', async () => {
-      bookmarksManager.showOtherBookmarks = false;
-
-      await bookmarksManager.loadBookmarks();
-
-      expect(nodeStoreMap.size).toBe(NUM_BOOKMARK_ROOTS - 1);
-      expect(nodeStoreMap.get(BOOKMARKS_ROOT_GUID)).toBeDefined();
-      expect(get(nodeStoreMap.get(BOOKMARKS_ROOT_GUID)!)).toMatchObject({
-        id: BOOKMARKS_ROOT_GUID,
-        type: Treetop.NodeType.Folder,
-        title: '',
-        children: [
-          {
-            id: BOOKMARKS_TOOLBAR_GUID,
-            type: Treetop.NodeType.Folder,
-            title: 'Bookmarks Toolbar',
-          },
-          {
-            id: BOOKMARKS_MENU_GUID,
-            type: Treetop.NodeType.Folder,
-            title: 'Bookmarks Menu',
-          },
-        ],
-      });
     });
   });
 });


### PR DESCRIPTION
Remove options to set visibility of built-in bookmark folders. This change simplifies future compatibility with Chrome, as each browser has different built-in bookmark folders.