### PR TITLE
Remove hard-coded built-in folder IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,78 +1,113 @@
 # Treetop Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
 ### Changed
-- Update Vite to 4.1.
+
+- Remove dependency on bookmarks.BookmarkTreeNode.type field, which isn't
+  available on all browsers.
+- Remove dependency on hard-coded built-in bookmark folder IDs, which aren't the
+  same across browsers.
 
 ### Removed
+
 - Remove options to set visibility of built-in bookmark folders.
 
 ## [1.5.0] - 2022-09-27
+
 ### Changed
+
 - Update Svelte Material UI to 6.1.4.
 - Replace Rollup with Vite as the build tool.
 
 ### Fixed
+
 - Fix selecting bookmark name or URL in properties dialog when focusing each input.
 
 ## [1.4.1] - 2022-06-20
+
 ### Fixed
+
 - Fix color scheme when legacy 'system' option is stored.
 
 ## [1.4.0] - 2022-06-19
+
 ### Changed
+
 - Update Svelte Material UI to 6.0.0-beta.16.
 - Update development and testing dependencies.
 
 ### Removed
+
 - Remove option to follow the system color scheme.
 
 ### Fixed
+
 - Fix loading stored options.
 
 ## [1.3.0] - 2021-10-02
+
 ### Added
+
 - Add webextension-polyfill.
 - Pressing Escape clears the search input.
 
 ## [1.2.0] - 2021-09-18
+
 ### Added
+
 - Add a search input to search for bookmarks by name or URL.
 
 ### Changed
+
 - Update Svelte Material UI to 4.2.0.
 
 ## [1.1.3] - 2021-01-22
+
 ### Added
+
 - List of attributions for open source software distributed in releases.
 
 ### Changed
+
 - Use fonts from Fontsource packages.
 
 ## [1.1.2] - 2020-12-08
+
 ### Changed
+
 - Fix visited bookmark styling.
 
 ## [1.1.1] - 2020-12-04
+
 ### Fixed
+
 - Fix bad 1.1.0 release on addons.mozilla.org.
 
 ## [1.1.0] - 2020-12-04
+
 ### Changed
+
 - Add option to change the color scheme.
 
 ## [1.0.1] - 2020-11-23
+
 ### Changed
+
 - Improve timer that updates when bookmarks were last visited.
 
 ### Fixed
+
 - Fix setting the document title.
 
 ## [1.0.0] - 2020-11-10
+
 ### Added
+
 - Initial release.
 
 [Unreleased]: https://github.com/msmolens/treetop/compare/v1.5.0...HEAD

--- a/src/treetop/FilterManager.ts
+++ b/src/treetop/FilterManager.ts
@@ -1,7 +1,7 @@
 import { get } from 'svelte/store';
 import type { Bookmarks } from 'webextension-polyfill';
 
-import { BOOKMARK_TREE_NODE_TYPE_BOOKMARK } from './constants';
+import { isBookmark } from './bookmarktreenode-utils';
 import * as Treetop from './types';
 
 /**
@@ -92,7 +92,7 @@ export class FilterManager {
       return;
     }
 
-    if (bookmark.type !== BOOKMARK_TREE_NODE_TYPE_BOOKMARK) {
+    if (!isBookmark(bookmark)) {
       return;
     }
 

--- a/src/treetop/Folder.svelte
+++ b/src/treetop/Folder.svelte
@@ -4,12 +4,13 @@
   import * as browser from 'webextension-polyfill';
 
   import Bookmark from './Bookmark.svelte';
-  import { BOOKMARKS_ROOT_GUID } from './constants';
   import * as Treetop from './types';
 
   export let nodeId: string;
   export let root = false;
 
+  const builtInFolderInfo: Treetop.BuiltInFolderInfo =
+    getContext('builtInFolderInfo');
   const nodeStoreMap: Treetop.NodeStoreMap = getContext('nodeStoreMap');
   const filterActive = getContext<Writable<boolean>>('filterActive');
   const filterSet = getContext<Treetop.FilterSet>('filterSet');
@@ -51,7 +52,7 @@
   function getFallbackTitle(nodeId: string): string {
     let key;
 
-    if (nodeId === BOOKMARKS_ROOT_GUID) {
+    if (nodeId === builtInFolderInfo.rootNodeId) {
       key = 'bookmarks';
     } else {
       key = 'folderNoTitle';

--- a/src/treetop/HistoryManager.ts
+++ b/src/treetop/HistoryManager.ts
@@ -1,7 +1,7 @@
 import { get, writable } from 'svelte/store';
 import browser, { type Bookmarks, type History } from 'webextension-polyfill';
 
-import { BOOKMARK_TREE_NODE_TYPE_BOOKMARK } from './constants';
+import { isBookmark } from './bookmarktreenode-utils';
 import * as Treetop from './types';
 
 /**
@@ -85,7 +85,7 @@ export class HistoryManager {
     _id: string,
     bookmark: Bookmarks.BookmarkTreeNode
   ): Promise<void> {
-    if (bookmark.type !== BOOKMARK_TREE_NODE_TYPE_BOOKMARK) {
+    if (!isBookmark(bookmark)) {
       return;
     }
 

--- a/src/treetop/Treetop.svelte
+++ b/src/treetop/Treetop.svelte
@@ -20,7 +20,6 @@
   import { PropertiesMenuItem } from './menus/PropertiesMenuItem';
   import { BookmarksManager } from './BookmarksManager';
   import ConfirmationDialog from './ConfirmationDialog.svelte';
-  import { BOOKMARKS_ROOT_GUID } from './constants';
   import FilterInput from './FilterInput.svelte';
   import { FilterManager } from './FilterManager';
   import Folder from './Folder.svelte';
@@ -74,8 +73,17 @@
   // Set of node IDs that match the active filter.
   const filterSet: Treetop.FilterSet = writable(new Set());
 
+  // Built-in folder info
+  const builtInFolderInfo: Treetop.BuiltInFolderInfo = {
+    rootNodeId: null,
+    builtInFolderIds: [],
+  };
+
   // Bookmarks manager
-  const bookmarksManager = new BookmarksManager(nodeStoreMap);
+  const bookmarksManager = new BookmarksManager(
+    nodeStoreMap,
+    builtInFolderInfo
+  );
 
   // History manager
   const historyManager = new HistoryManager(lastVisitTimeMap);
@@ -87,6 +95,7 @@
   const filterActive = writable(false);
 
   // Make bookmark data available to other components
+  setContext('builtInFolderInfo', builtInFolderInfo);
   setContext('nodeStoreMap', nodeStoreMap);
   setContext('lastVisitTimeMap', lastVisitTimeMap);
   setContext('filterActive', filterActive);
@@ -524,7 +533,7 @@
 
     // Validate specified root bookmark ID, falling back to bookmarks root
     if (!rootBookmarkId || !nodeStoreMap.has(rootBookmarkId)) {
-      rootBookmarkId = BOOKMARKS_ROOT_GUID;
+      rootBookmarkId = builtInFolderInfo.rootNodeId ?? '';
     }
 
     return rootBookmarkId;
@@ -544,15 +553,20 @@
     menuManager = new MenuManager();
     menuManager.registerMenuItem(
       'delete',
-      new DeleteMenuItem(nodeStoreMap, filterActive, deleteBookmark)
+      new DeleteMenuItem(
+        builtInFolderInfo,
+        nodeStoreMap,
+        filterActive,
+        deleteBookmark
+      )
     );
     menuManager.registerMenuItem(
       'openAllInTabs',
-      new OpenAllInTabsMenuItem(nodeStoreMap, openAllInTabs)
+      new OpenAllInTabsMenuItem(builtInFolderInfo, nodeStoreMap, openAllInTabs)
     );
     menuManager.registerMenuItem(
       'properties',
-      new PropertiesMenuItem(showPropertiesDialog)
+      new PropertiesMenuItem(builtInFolderInfo, showPropertiesDialog)
     );
 
     window.addEventListener('hashchange', onHashChange);

--- a/src/treetop/bookmarktreenode-utils.ts
+++ b/src/treetop/bookmarktreenode-utils.ts
@@ -1,0 +1,31 @@
+import type { Bookmarks } from 'webextension-polyfill';
+
+import {
+  BOOKMARK_TREE_NODE_TYPE_BOOKMARK,
+  BOOKMARK_TREE_NODE_TYPE_FOLDER,
+  BOOKMARK_TREE_NODE_TYPE_SEPARATOR,
+} from './constants';
+
+/**
+ * Check if a BookmarkTreeNode is a bookmark.
+ */
+export function isBookmark(node: Bookmarks.BookmarkTreeNode): boolean {
+  return (
+    node.type === BOOKMARK_TREE_NODE_TYPE_BOOKMARK ||
+    (node.url !== undefined && !isSeparator(node))
+  );
+}
+
+/**
+ * Check if a BookmarkTreeNode is a folder.
+ */
+export function isFolder(node: Bookmarks.BookmarkTreeNode): boolean {
+  return node.type === BOOKMARK_TREE_NODE_TYPE_FOLDER || node.url === undefined;
+}
+
+/**
+ * Check if a BookmarkTreeNode is a separator.
+ */
+export function isSeparator(node: Bookmarks.BookmarkTreeNode): boolean {
+  return node.type === BOOKMARK_TREE_NODE_TYPE_SEPARATOR;
+}

--- a/src/treetop/constants.ts
+++ b/src/treetop/constants.ts
@@ -1,10 +1,6 @@
 // Bookmark roots have special permanent GUIDs, see
 // https://searchfox.org/mozilla-central/rev/7b36c8b83337c4b4cdfd4ccc2168f3491a86811b/toolkit/components/places/Bookmarks.sys.mjs#139-147
-export const BOOKMARKS_ROOT_GUID = 'root________';
-export const BOOKMARKS_TOOLBAR_GUID = 'toolbar_____';
-export const BOOKMARKS_MENU_GUID = 'menu________';
 export const MOBILE_BOOKMARKS_GUID = 'mobile______';
-export const OTHER_BOOKMARKS_GUID = 'unfiled_____';
 
 // bookmarks.BookmarkTreeNodeType strings
 // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNodeType

--- a/src/treetop/menus/DeleteMenuItem.ts
+++ b/src/treetop/menus/DeleteMenuItem.ts
@@ -1,11 +1,5 @@
 import { get, type Writable } from 'svelte/store';
 
-import {
-  BOOKMARKS_MENU_GUID,
-  BOOKMARKS_ROOT_GUID,
-  BOOKMARKS_TOOLBAR_GUID,
-  OTHER_BOOKMARKS_GUID,
-} from '@Treetop/treetop/constants';
 import type * as Treetop from '@Treetop/treetop/types';
 
 import { MenuItem, type OnClickedCallback } from './MenuItem';
@@ -15,6 +9,7 @@ import { MenuItem, type OnClickedCallback } from './MenuItem';
  */
 export class DeleteMenuItem extends MenuItem {
   constructor(
+    private readonly builtInFolderInfo: Treetop.BuiltInFolderInfo,
     private readonly nodeStoreMap: Treetop.NodeStoreMap,
     private readonly filterActive: Writable<boolean>,
     onClickedCallback: OnClickedCallback
@@ -23,13 +18,9 @@ export class DeleteMenuItem extends MenuItem {
   }
 
   enabled(nodeId: string): boolean {
-    // Disable deleting special bookmark roots
-    if (
-      nodeId === BOOKMARKS_ROOT_GUID ||
-      nodeId === BOOKMARKS_TOOLBAR_GUID ||
-      nodeId === BOOKMARKS_MENU_GUID ||
-      nodeId === OTHER_BOOKMARKS_GUID
-    ) {
+    // Disable deleting built-in folders
+    const { rootNodeId, builtInFolderIds } = this.builtInFolderInfo;
+    if (rootNodeId === nodeId || builtInFolderIds.includes(nodeId)) {
       return false;
     }
 

--- a/src/treetop/menus/OpenAllInTabsMenuItem.ts
+++ b/src/treetop/menus/OpenAllInTabsMenuItem.ts
@@ -1,6 +1,5 @@
 import { get } from 'svelte/store';
 
-import { BOOKMARKS_ROOT_GUID } from '@Treetop/treetop/constants';
 import type * as Treetop from '@Treetop/treetop/types';
 
 import { MenuItem, type OnClickedCallback } from './MenuItem';
@@ -10,6 +9,7 @@ import { MenuItem, type OnClickedCallback } from './MenuItem';
  */
 export class OpenAllInTabsMenuItem extends MenuItem {
   constructor(
+    private readonly builtInFolderInfo: Treetop.BuiltInFolderInfo,
     private readonly nodeStoreMap: Treetop.NodeStoreMap,
     onClickedCallback: OnClickedCallback
   ) {
@@ -21,7 +21,7 @@ export class OpenAllInTabsMenuItem extends MenuItem {
     // Enable for non-empty folders, excluding the bookmarks root
     //
 
-    if (nodeId === BOOKMARKS_ROOT_GUID) {
+    if (nodeId === this.builtInFolderInfo.rootNodeId) {
       return false;
     }
 

--- a/src/treetop/menus/PropertiesMenuItem.ts
+++ b/src/treetop/menus/PropertiesMenuItem.ts
@@ -1,9 +1,4 @@
-import {
-  BOOKMARKS_MENU_GUID,
-  BOOKMARKS_ROOT_GUID,
-  BOOKMARKS_TOOLBAR_GUID,
-  OTHER_BOOKMARKS_GUID,
-} from '@Treetop/treetop/constants';
+import type * as Treetop from '@Treetop/treetop/types';
 
 import { MenuItem, type OnClickedCallback } from './MenuItem';
 
@@ -11,17 +6,20 @@ import { MenuItem, type OnClickedCallback } from './MenuItem';
  * Menu item to show the properties dialog for a bookmark or folder.
  */
 export class PropertiesMenuItem extends MenuItem {
-  constructor(onClickedCallback: OnClickedCallback) {
+  constructor(
+    private readonly builtInFolderInfo: Treetop.BuiltInFolderInfo,
+    onClickedCallback: OnClickedCallback
+  ) {
     super(onClickedCallback);
   }
 
   enabled(nodeId: string): boolean {
-    // Disable modifying special bookmark roots
-    return (
-      nodeId !== BOOKMARKS_ROOT_GUID &&
-      nodeId !== BOOKMARKS_TOOLBAR_GUID &&
-      nodeId !== BOOKMARKS_MENU_GUID &&
-      nodeId !== OTHER_BOOKMARKS_GUID
-    );
+    // Disable modifying built-in folders
+    const { rootNodeId, builtInFolderIds } = this.builtInFolderInfo;
+    if (rootNodeId === nodeId || builtInFolderIds.includes(nodeId)) {
+      return false;
+    }
+
+    return true;
   }
 }

--- a/src/treetop/types.ts
+++ b/src/treetop/types.ts
@@ -55,3 +55,10 @@ export type PreferenceValue =
   | string[]
   | number[]
   | boolean[];
+
+export interface BuiltInFolderInfo {
+  // Root bookmark node ID.
+  rootNodeId: string | null;
+  // Node IDs of built-in folders under the root bookmark node.
+  builtInFolderIds: string[];
+}

--- a/test/treetop/Folder.svelte.test.ts
+++ b/test/treetop/Folder.svelte.test.ts
@@ -3,7 +3,6 @@
 import { get, type Writable, writable } from 'svelte/store';
 import { render, screen } from '@testing-library/svelte';
 
-import { BOOKMARKS_ROOT_GUID } from '@Treetop/treetop/constants';
 import Folder from '@Treetop/treetop/Folder.svelte';
 import type * as Treetop from '@Treetop/treetop/types';
 
@@ -15,6 +14,7 @@ import {
 } from '../utils/factories';
 
 // Folder component requirements
+let builtInFolderInfo: Treetop.BuiltInFolderInfo;
 let nodeStoreMap: Treetop.NodeStoreMap;
 let filterActive: Writable<boolean>;
 let filterSet: Treetop.FilterSet;
@@ -35,6 +35,7 @@ const setup = () => {
       root: true,
     },
     Context: {
+      builtInFolderInfo,
       nodeStoreMap,
       lastVisitTimeMap,
       filterActive,
@@ -101,6 +102,10 @@ const expectFolderInFolder = (child: HTMLElement, headerLink: HTMLElement) => {
 };
 
 beforeEach(() => {
+  builtInFolderInfo = {
+    rootNodeId: 'bookmarks-root-id',
+    builtInFolderIds: ['bookmarks-toolbar-id', 'other-bookmarks-id'],
+  };
   nodeStoreMap = new Map() as Treetop.NodeStoreMap;
   lastVisitTimeMap = new Map() as Treetop.LastVisitTimeMap;
   filterActive = writable(false);
@@ -114,8 +119,7 @@ describe('rooted at bookmarks root', () => {
     beforeEach(() => {
       // Create node tree:
       // rootNode
-      rootNode = createFolderNode();
-      rootNode.id = BOOKMARKS_ROOT_GUID;
+      rootNode = createFolderNode({ id: builtInFolderInfo.rootNodeId! });
 
       nodeStoreMap.set(rootNode.id, writable(rootNode));
 
@@ -153,9 +157,10 @@ describe('rooted at bookmarks root', () => {
     beforeEach(() => {
       // Create node tree:
       // rootNode
-      rootNode = createFolderNode();
-      rootNode.id = BOOKMARKS_ROOT_GUID;
-      rootNode.title = '';
+      rootNode = createFolderNode({
+        id: builtInFolderInfo.rootNodeId!,
+        title: '',
+      });
 
       nodeStoreMap.set(rootNode.id, writable(rootNode));
 
@@ -191,8 +196,7 @@ describe('rooted at bookmarks root', () => {
       // Create node tree:
       // rootNode
       //   └── folderNode
-      rootNode = createFolderNode();
-      rootNode.id = BOOKMARKS_ROOT_GUID;
+      rootNode = createFolderNode({ id: builtInFolderInfo.rootNodeId! });
 
       folderNode = createFolderNode();
       folderNode.parentId = rootNode.id;
@@ -250,8 +254,7 @@ describe('rooted at bookmarks root', () => {
       //      ├── bookmarkNode
       //      └── folderNode2
       //         └── bookmarkNode
-      rootNode = createFolderNode();
-      rootNode.id = BOOKMARKS_ROOT_GUID;
+      rootNode = createFolderNode({ id: builtInFolderInfo.rootNodeId! });
 
       folderNode1 = createFolderNode();
       folderNode1.parentId = rootNode.id;
@@ -365,8 +368,7 @@ describe('rooted at bookmarks root', () => {
       //   └── folderNode2
       //      ├── bookmarkNode
       //      └── separatorNode
-      rootNode = createFolderNode();
-      rootNode.id = BOOKMARKS_ROOT_GUID;
+      rootNode = createFolderNode({ id: builtInFolderInfo.rootNodeId! });
 
       folderNode1 = createFolderNode();
       folderNode1.parentId = rootNode.id;
@@ -473,8 +475,7 @@ describe('rooted at subfolder', () => {
     //      ├── bookmarkNode
     //      └── folderNode3
     //         └── bookmarkNode
-    rootNode = createFolderNode();
-    rootNode.id = BOOKMARKS_ROOT_GUID;
+    rootNode = createFolderNode({ id: builtInFolderInfo.rootNodeId! });
 
     folderNode1 = createFolderNode();
     folderNode1.parentId = rootNode.id;
@@ -623,8 +624,7 @@ describe('filter active', () => {
     //      └── folderNode3
     //         ├── bookmarkNode5
     //         └── bookmarkNode6
-    rootNode = createFolderNode();
-    rootNode.id = BOOKMARKS_ROOT_GUID;
+    rootNode = createFolderNode({ id: builtInFolderInfo.rootNodeId! });
 
     folderNode1 = createFolderNode();
     folderNode1.parentId = rootNode.id;

--- a/test/treetop/Treetop.svelte.test.ts
+++ b/test/treetop/Treetop.svelte.test.ts
@@ -70,8 +70,8 @@ describe('Treetop', () => {
     bookmarksTree[0].title = 'Bookmarks root';
     mockBrowser.bookmarks.getTree.expect.andResolve(bookmarksTree);
 
-    // Expect all bookmark root folders, excluding Mobile Bookmarks, to be empty
-    const numEmptyFolders = bookmarksTree[0].children!.length - 1;
+    // Expect all bookmark root folders to be empty
+    const numEmptyFolders = bookmarksTree[0].children!.length;
     mockBrowser.i18n.getMessage.expect('emptyFolder').times(numEmptyFolders);
 
     setup();

--- a/test/treetop/menus/DeleteMenuItem.test.ts
+++ b/test/treetop/menus/DeleteMenuItem.test.ts
@@ -1,12 +1,6 @@
 import { type Writable, writable } from 'svelte/store';
 import faker from 'faker';
 
-import {
-  BOOKMARKS_MENU_GUID,
-  BOOKMARKS_ROOT_GUID,
-  BOOKMARKS_TOOLBAR_GUID,
-  OTHER_BOOKMARKS_GUID,
-} from '@Treetop/treetop/constants';
 import { DeleteMenuItem } from '@Treetop/treetop/menus/DeleteMenuItem';
 import type { OnClickedCallback } from '@Treetop/treetop/menus/MenuItem';
 import type * as Treetop from '@Treetop/treetop/types';
@@ -17,6 +11,11 @@ let menuItem: DeleteMenuItem;
 let nodeStoreMap: Treetop.NodeStoreMap;
 let filterActive: Writable<boolean>;
 
+const BUILT_IN_FOLDER_INFO: Treetop.BuiltInFolderInfo = {
+  rootNodeId: 'bookmarks-root-id',
+  builtInFolderIds: ['bookmarks-toolbar-id', 'other-bookmarks-id'],
+};
+
 beforeEach(() => {
   nodeStoreMap = new Map() as Treetop.NodeStoreMap;
   filterActive = writable(false);
@@ -25,16 +24,20 @@ beforeEach(() => {
     void nodeId;
   };
 
-  menuItem = new DeleteMenuItem(nodeStoreMap, filterActive, callback);
+  menuItem = new DeleteMenuItem(
+    BUILT_IN_FOLDER_INFO,
+    nodeStoreMap,
+    filterActive,
+    callback
+  );
 });
 
-it.each([
-  BOOKMARKS_MENU_GUID,
-  BOOKMARKS_ROOT_GUID,
-  BOOKMARKS_TOOLBAR_GUID,
-  OTHER_BOOKMARKS_GUID,
-])('is disabled for special bookmark root: %p', (nodeId) => {
-  expect(menuItem.enabled(nodeId)).toBe(false);
+it('is disabled for built-in folders', () => {
+  expect(menuItem.enabled(BUILT_IN_FOLDER_INFO.rootNodeId!)).toBe(false);
+
+  for (const nodeId of BUILT_IN_FOLDER_INFO.builtInFolderIds) {
+    expect(menuItem.enabled(nodeId)).toBe(false);
+  }
 });
 
 it('is enabled for normal bookmark node IDs', () => {

--- a/test/treetop/menus/OpenAllInTabsMenuItem.test.ts
+++ b/test/treetop/menus/OpenAllInTabsMenuItem.test.ts
@@ -1,7 +1,6 @@
 import { writable } from 'svelte/store';
 import faker from 'faker';
 
-import { BOOKMARKS_ROOT_GUID } from '@Treetop/treetop/constants';
 import type { OnClickedCallback } from '@Treetop/treetop/menus/MenuItem';
 import { OpenAllInTabsMenuItem } from '@Treetop/treetop/menus/OpenAllInTabsMenuItem';
 import type * as Treetop from '@Treetop/treetop/types';
@@ -11,6 +10,11 @@ import { createBookmarkNode, createFolderNode } from '../../utils/factories';
 let menuItem: OpenAllInTabsMenuItem;
 let nodeStoreMap: Treetop.NodeStoreMap;
 
+const BUILT_IN_FOLDER_INFO: Treetop.BuiltInFolderInfo = {
+  rootNodeId: 'bookmarks-root-id',
+  builtInFolderIds: [],
+};
+
 beforeEach(() => {
   nodeStoreMap = new Map() as Treetop.NodeStoreMap;
 
@@ -18,11 +22,15 @@ beforeEach(() => {
     void nodeId;
   };
 
-  menuItem = new OpenAllInTabsMenuItem(nodeStoreMap, callback);
+  menuItem = new OpenAllInTabsMenuItem(
+    BUILT_IN_FOLDER_INFO,
+    nodeStoreMap,
+    callback
+  );
 });
 
 it('is disabled for the bookmarks root', () => {
-  expect(menuItem.enabled(BOOKMARKS_ROOT_GUID)).toBe(false);
+  expect(menuItem.enabled(BUILT_IN_FOLDER_INFO.rootNodeId!)).toBe(false);
 });
 
 it('is disabled for bookmarks', () => {

--- a/test/treetop/menus/PropertiesMenuItem.test.ts
+++ b/test/treetop/menus/PropertiesMenuItem.test.ts
@@ -1,31 +1,30 @@
 import faker from 'faker';
 
-import {
-  BOOKMARKS_MENU_GUID,
-  BOOKMARKS_ROOT_GUID,
-  BOOKMARKS_TOOLBAR_GUID,
-  OTHER_BOOKMARKS_GUID,
-} from '@Treetop/treetop/constants';
 import type { OnClickedCallback } from '@Treetop/treetop/menus/MenuItem';
 import { PropertiesMenuItem } from '@Treetop/treetop/menus/PropertiesMenuItem';
+import type * as Treetop from '@Treetop/treetop/types';
 
 let menuItem: PropertiesMenuItem;
+
+const BUILT_IN_FOLDER_INFO: Treetop.BuiltInFolderInfo = {
+  rootNodeId: 'bookmarks-root-id',
+  builtInFolderIds: ['bookmarks-toolbar-id', 'other-bookmarks-id'],
+};
 
 beforeEach(() => {
   const callback: OnClickedCallback = (nodeId) => {
     void nodeId;
   };
 
-  menuItem = new PropertiesMenuItem(callback);
+  menuItem = new PropertiesMenuItem(BUILT_IN_FOLDER_INFO, callback);
 });
 
-it.each([
-  BOOKMARKS_MENU_GUID,
-  BOOKMARKS_ROOT_GUID,
-  BOOKMARKS_TOOLBAR_GUID,
-  OTHER_BOOKMARKS_GUID,
-])('is disabled for special bookmark root: %p', (nodeId) => {
-  expect(menuItem.enabled(nodeId)).toBe(false);
+it('is disabled for built-in folders', () => {
+  expect(menuItem.enabled(BUILT_IN_FOLDER_INFO.rootNodeId!)).toBe(false);
+
+  for (const nodeId of BUILT_IN_FOLDER_INFO.builtInFolderIds) {
+    expect(menuItem.enabled(nodeId)).toBe(false);
+  }
 });
 
 it('is enabled for normal bookmark node IDs', () => {

--- a/test/utils/factories.ts
+++ b/test/utils/factories.ts
@@ -1,19 +1,14 @@
 import faker from 'faker';
 import type { Bookmarks, History } from 'webextension-polyfill';
 
-import {
-  BOOKMARK_TREE_NODE_TYPE_BOOKMARK,
-  BOOKMARK_TREE_NODE_TYPE_FOLDER,
-  BOOKMARK_TREE_NODE_TYPE_SEPARATOR,
-  BOOKMARKS_MENU_GUID,
-  BOOKMARKS_ROOT_GUID,
-  BOOKMARKS_TOOLBAR_GUID,
-  MOBILE_BOOKMARKS_GUID,
-  OTHER_BOOKMARKS_GUID,
-} from '@Treetop/treetop/constants';
+import { BOOKMARK_TREE_NODE_TYPE_SEPARATOR } from '@Treetop/treetop/constants';
 import * as Treetop from '@Treetop/treetop/types';
 
 const TITLE_NUM_RANDOM_WORDS = 3;
+
+const BOOKMARKS_ROOT_GUID = 'bookmarks-root-id';
+const BOOKMARKS_TOOLBAR_GUID = 'bookmarks-toolbar-id';
+const OTHER_BOOKMARKS_GUID = 'other-bookmarks-ids';
 
 //
 // Treetop node factories
@@ -64,7 +59,6 @@ export const createBrowserBookmarkNode = (
     id: faker.datatype.uuid(),
     parentId: parent.id,
     title: faker.random.words(TITLE_NUM_RANDOM_WORDS),
-    type: BOOKMARK_TREE_NODE_TYPE_BOOKMARK,
     url: faker.internet.url(),
   };
   parent.children!.push(node);
@@ -78,7 +72,6 @@ export const createBrowserFolderNode = (
     id: faker.datatype.uuid(),
     parentId: parent.id,
     title: faker.random.words(TITLE_NUM_RANDOM_WORDS),
-    type: BOOKMARK_TREE_NODE_TYPE_FOLDER,
     children: [],
   };
   parent.children!.push(node);
@@ -99,22 +92,11 @@ export const createBrowserSeparatorNode = (
   return node;
 };
 
-export const createBookmarksMenuNode = (): Bookmarks.BookmarkTreeNode => {
-  return {
-    id: BOOKMARKS_MENU_GUID,
-    parentId: BOOKMARKS_ROOT_GUID,
-    title: 'Bookmarks Menu',
-    type: BOOKMARK_TREE_NODE_TYPE_FOLDER,
-    children: [],
-  };
-};
-
 export const createBookmarksToolbarNode = (): Bookmarks.BookmarkTreeNode => {
   return {
     id: BOOKMARKS_TOOLBAR_GUID,
     parentId: BOOKMARKS_ROOT_GUID,
     title: 'Bookmarks Toolbar',
-    type: BOOKMARK_TREE_NODE_TYPE_FOLDER,
     children: [],
   };
 };
@@ -124,17 +106,6 @@ export const createOtherBookmarksNode = (): Bookmarks.BookmarkTreeNode => {
     id: OTHER_BOOKMARKS_GUID,
     parentId: BOOKMARKS_ROOT_GUID,
     title: 'Other Bookmarks',
-    type: BOOKMARK_TREE_NODE_TYPE_FOLDER,
-    children: [],
-  };
-};
-
-export const createMobileBookmarksNode = (): Bookmarks.BookmarkTreeNode => {
-  return {
-    id: MOBILE_BOOKMARKS_GUID,
-    parentId: BOOKMARKS_ROOT_GUID,
-    title: 'Mobile Bookmarks',
-    type: BOOKMARK_TREE_NODE_TYPE_FOLDER,
     children: [],
   };
 };
@@ -144,14 +115,8 @@ export const createBookmarksRootNode = (): Bookmarks.BookmarkTreeNode => {
     id: BOOKMARKS_ROOT_GUID,
     parentId: undefined,
     url: undefined,
-    type: BOOKMARK_TREE_NODE_TYPE_FOLDER,
     title: '',
-    children: [
-      createBookmarksMenuNode(),
-      createBookmarksToolbarNode(),
-      createOtherBookmarksNode(),
-      createMobileBookmarksNode(),
-    ],
+    children: [createBookmarksToolbarNode(), createOtherBookmarksNode()],
   };
 };
 


### PR DESCRIPTION
- Remove hard-coded built-in bookmark folder IDs, which aren't the same across browsers.
- Remove dependency on `bookmarks.BookmarkTreeNode.type` field, which isn't available on all browsers. See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/BookmarkTreeNode.