### PR TITLE
Fix bookmark last visit time on Chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix a bug on Chrome where a previously visited bookmark might not display in a
+  larger font even if it's been visited recently.
+
 ## [3.0.0] - 2025-10-10
 
 ### Changed

--- a/test/utils/factories.ts
+++ b/test/utils/factories.ts
@@ -120,7 +120,9 @@ export const createHistoryItem = (): chrome.history.HistoryItem => {
   };
 };
 
-export const createVisitItem = (): chrome.history.VisitItem => {
+export const createVisitItem = (
+  withProperties?: Partial<chrome.history.VisitItem>,
+): chrome.history.VisitItem => {
   return {
     id: faker.string.uuid(),
     visitId: faker.string.uuid(),
@@ -128,5 +130,43 @@ export const createVisitItem = (): chrome.history.VisitItem => {
     referringVisitId: faker.string.uuid(),
     transition: 'link',
     isLocal: true,
+    ...withProperties,
   };
+};
+
+export interface CreateVisitItemsOptions {
+  /** The number of items to create */
+  count: number;
+  /**
+   * The browser convention to follow when ordering the items (Chrome:
+   * chronological order; Firefox: reverse chronological order)
+   */
+  order: 'chrome' | 'firefox';
+}
+
+/**
+ * Create a list of `chrome.history.VisitItem`s, as returned by
+ * `chrome.history.getVisits`, sorted according to the behavior of the specified
+ * browser.
+ */
+export const createVisitItems = (
+  opts: CreateVisitItemsOptions = {
+    count: 1,
+    order: 'firefox',
+  },
+): chrome.history.VisitItem[] => {
+  const { count, order } = opts;
+
+  const to = faker.date.recent();
+  const from = faker.date.recent({ refDate: to });
+
+  const items = faker.date
+    .betweens({ from, to, count })
+    .map((date) => createVisitItem({ visitTime: date.getTime() }));
+
+  if (order === 'firefox') {
+    items.reverse();
+  }
+
+  return items;
 };


### PR DESCRIPTION
The `chrome.history.getVisits` API behaves differently on different browsers: Firefox sorts the visits in reverse chronological order and Chrome sorts the visits in chronological order.

Update the HistoryManager to handle both cases. This fixes a bug on Chrome where a previously visited bookmark might not display in a larger font even if it's been visited recently.

See:
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/history/getVisits
- https://bugzilla.mozilla.org/show_bug.cgi?id=1389588